### PR TITLE
Replaced salt() implementation. This is needed for 64-bit compatibility.

### DIFF
--- a/include/salt.h
+++ b/include/salt.h
@@ -1,7 +1,11 @@
 #ifndef SALT_H
 #define SALT_H
 
-typedef char saltbuf[3];
+/* Salt is a two-character string. */
+#define SALT_LEN 2
+
+/* Salt buffers contain the two-character string followed by '\0'. */
+typedef char saltbuf[SALT_LEN + 1];
 
 char* salt(const char*, saltbuf);
 

--- a/ntserv/input.c
+++ b/ntserv/input.c
@@ -61,7 +61,7 @@ static void setflag()
   }
 }
 
-static void gamedown(why)
+static void gamedown(int why)
 {
   struct badversion_spacket packet;
   memset(&packet, 0, sizeof(struct badversion_spacket));

--- a/ntserv/salt.c
+++ b/ntserv/salt.c
@@ -19,19 +19,24 @@ static char saltchar(char ch)
 /* Sets sb to a valid salt argument for crypt(), based on s. */
 char* salt(const char* s, saltbuf sb)
 {
-    int i;
-    int end = 0;
-    int saltlen = sizeof(sb) - 2;
-    
-    for (i=0; i<saltlen; i++) {
-	if (!end) end = (*s == '\0');
-	if (end) {
-	    sb[i] = DEFAULT;
-	} else {
-	    sb[i] = saltchar(*s);
-	    s++;
-	}
+    char *out_p = &sb[0];
+    char *out_end = &sb[SALT_LEN];
+
+    while (out_p < out_end) {
+        char c = *s++;
+
+        if (c == '\0') {
+            /* String ended early. Pad with DEFAULT. */
+            do {
+                *out_p++ = DEFAULT;
+            } while (out_p < out_end);
+            break;
+        }
+
+        *out_p++ = saltchar(c);
     }
-    sb[saltlen] = '\0';
+
+    *out_end = '\0';
+
     return sb;
 }

--- a/robotd/assault.c
+++ b/robotd/assault.c
@@ -15,7 +15,7 @@ unsigned char get_pl_course();
 
 /* assault planet */
 
-assault()
+void assault()
 {
    if(!_state.assault || !_state.assault_planet){
       return;
@@ -80,7 +80,7 @@ static int risk_res_death(struct planet *pl)
    return 0;
 }
 
-goto_assault_planet()
+void goto_assault_planet()
 {
    Player		*e = _state.closest_e;
    struct player	*j = e?e->p:NULL;
@@ -161,8 +161,7 @@ goto_assault_planet()
 }
 
 /* UNUSED */
-do_cloak(pdist)
-   
+int do_cloak(pdist)
    int	pdist;	/* unused */
 {
    Player	*e = _state.closest_e;
@@ -179,7 +178,7 @@ do_cloak(pdist)
    return 1;
 }
 
-assault_planet()
+void assault_planet()
 {
   Player         *e = _state.closest_e;
   struct player	 *j = e?e->p:NULL;
@@ -260,7 +259,7 @@ assault_planet()
  * Called from s_defense when orbiting a planet we want to assault.
  */
 
-defend_enemy_planet()
+void defend_enemy_planet()
 {
    Player		*e = _state.closest_e;
    int			num_hits;
@@ -423,13 +422,12 @@ unsigned char assault_course(pl, pdist, crs, c)
 }
 
 /* NOTUSED */
-accavdir_nd(avdir, dir)
-
+int accavdir_nd(avdir, dir)
    int			avdir;
    unsigned char	dir;
 {
    register int	dif = angdist((unsigned char)avdir, dir);
-   register	n;
+   register int n;
 
    n = dir+dif;
    if(NORMALIZE(n) == avdir)
@@ -441,13 +439,12 @@ accavdir_nd(avdir, dir)
 }
 
 unsigned char get_pl_course(pl, speed, cloak)
-
    struct planet	*pl;
    int			*speed;
    int			*cloak;
 {
    int			pldist, edist;
-   register		i, de=0;
+   register int		i, de=0;
    register Player	*p;
    unsigned char	pdcrs, pcrs;
    bool			first = 1;
@@ -534,7 +531,6 @@ unsigned char get_pl_course(pl, speed, cloak)
    printf("weighted average direction to avoid = %d\n", avcrs);
    */
 
-
    avoiddir(avcrs, &pdcrs, (unsigned char)_state.assault_range);
 
    /* "oscillation damper" */
@@ -572,8 +568,7 @@ unsigned char get_pl_course(pl, speed, cloak)
    return pdcrs;
 }
 
-check_ship_speed(p, v)
-
+int check_ship_speed(p, v)
    Player	*p;
    int		v;
 {

--- a/robotd/decide.c
+++ b/robotd/decide.c
@@ -14,7 +14,7 @@
 
 /* Decide next course of action */
 
-decide()
+void decide()
 {
    static int	_donedead;
    static int	 needswardecs=1; /* track t-mode start and war declarations */
@@ -153,7 +153,7 @@ decide()
 }
 
 /* currently protecting.  Do we continue to protect or do something else? */
-decide_protect()
+void decide_protect()
 {
    struct planet	*pl = _state.protect_planet;
 
@@ -170,7 +170,7 @@ decide_protect()
       unprotectp_c("no protect");
 }
 
-decide_defend()
+void decide_defend()
 {
    Player	*p = _state.protect_player;
    if(!p || !p->p || !isAlive(p->p)){
@@ -185,7 +185,7 @@ decide_defend()
    }
 }
 
-decide_take()
+void decide_take()
 {
    PlanetRec		*pls = _state.planets;
    struct planet *tpl = _state.assault_planet;
@@ -241,7 +241,7 @@ decide_take()
    }
 }
 
-decide_bomb()
+void decide_bomb()
 {
    struct planet	*pl = me_p->closest_pl;
    int			dist = pl?pl->pl_mydist:INT_MAX;
@@ -304,8 +304,8 @@ decide_bomb()
       }
    }
 }
-check_bombdamage(pl)
-   
+
+void check_bombdamage(pl)
    struct planet	*pl;
 {
    if(me->p_ship.s_type == SCOUT &&
@@ -325,11 +325,11 @@ check_bombdamage(pl)
       disengage_c(EDAMAGE, NULL, "dam > 75");
 }
 
-decide_disengage()
+void decide_disengage()
 {
 }
 
-decide_ogg()
+int decide_ogg()
 {
    Player *p = _state.current_target;
 
@@ -367,13 +367,13 @@ decide_ogg()
    return 1;
 }
 
-decide_escort()
+void decide_escort()
 {
    return;
 }
 
 /* decide to do something */
-decide_default()
+void decide_default()
 {
    int	ship = _state.ship;
    struct planet *pl = _state.protect_planet;
@@ -465,7 +465,7 @@ decide_default()
    }
 }
 
-pick_df_ship()
+int pick_df_ship()
 {
    int	r = RANDOM()%10;
    if(_state.galaxy && _state.chaos){
@@ -483,14 +483,13 @@ pick_df_ship()
 }
 
 /* Examine our planets -- determine if we should protect planet */
-check_protect(min_pl, ship, value)
-   
+int check_protect(min_pl, ship, value)
    int	min_pl;
    int	*ship;
    int	value;
 {
    PlanetRec		*pls = _state.planets;
-   register		i,j;
+   register int		i,j;
    register Player	*p;
    int			plc[MAXPLANETS];
    int			min_p = INT_MAX-1;
@@ -582,12 +581,11 @@ check_protect(min_pl, ship, value)
    return 1;
 }
 
-check_bomb(ship)
-   
+int check_bomb(ship)
    int	*ship;
 {
    PlanetRec			*pls = _state.planets;
-   register			k;
+   register int			k;
    register struct planet	*pl;
    register int			ac,mac=0;
    int				cof;
@@ -680,12 +678,11 @@ check_bomb(ship)
    return 0;
 }
 
-check_take(ship)
-   
+int check_take(ship)
    int	*ship;
 {
    PlanetRec			*pls = _state.planets;
-   register			k;
+   register int			k;
    register struct planet	*pl, *tpl = NULL;
    int				hd = home_dist();
    int				min_dist = GWIDTH;
@@ -767,13 +764,12 @@ check_take(ship)
    return 0;
 }
 
-check_ogg(ship, dist)
-   
+int check_ogg(ship, dist)
    int	*ship;
    int	dist;
 {
    register Player	*p, *op = NULL;
-   register		i;
+   register int		i;
    int			mindist = INT_MAX;
    Player 		*co = _state.current_target;
 
@@ -828,12 +824,12 @@ check_ogg(ship, dist)
    return 0;
 }
 
-check_escort()
+int check_escort()
 {
    return 0;
 }
 
-protectp_c(p, s)
+void protectp_c(p, s)
 
    struct planet	*p;
    char			*s;
@@ -847,8 +843,7 @@ protectp_c(p, s)
    _state.arrived_at_planet = 0;
 }
 
-unprotectp_c(s)
-   
+void unprotectp_c(s)
    char	*s;
 {
    if(!_state.protect) return;
@@ -858,8 +853,7 @@ unprotectp_c(s)
    _state.protect_planet = NULL;
 }
 
-bomb_c(p, s)
-
+void bomb_c(p, s)
    struct planet	*p;
    char			*s;
 {
@@ -873,8 +867,7 @@ bomb_c(p, s)
    _state.lock = 0;
 }
 
-unassault_c(s)
-   
+void unassault_c(s)
    char	*s;
 {
    if(_state.assault_req == 0) return;
@@ -887,7 +880,7 @@ unassault_c(s)
    _state.arrived_at_planet = 0;
 }
 
-ogg_c(p, s)
+void ogg_c(p, s)
    Player	*p;
    char		*s;
 {
@@ -902,7 +895,7 @@ ogg_c(p, s)
    _state.ogg = 0;
 }
 
-unogg_c(s)
+void unogg_c(s)
    char	*s;
 {
    if(_state.ogg_req == 0) return;
@@ -911,8 +904,7 @@ unogg_c(s)
    _state.ogg = 0;
 }
 
-take_c(p, s)
-
+void take_c(p, s)
    struct planet	*p;
    char			*s;
 {
@@ -925,8 +917,7 @@ take_c(p, s)
    _state.arrived_at_planet = 0;
 }
 
-untake_c(s)
-   
+void untake_c(s)
    char	*s;
 {
    if(_state.assault_req == 0) return;
@@ -939,8 +930,7 @@ untake_c(s)
    _state.arrived_at_planet = 0;
 }
 
-refit_c(s)
-   
+void refit_c(s)
    char	*s;
 {
    if(_server == SERVER_GRIT && MYDAMAGE() < 50){
@@ -958,8 +948,7 @@ refit_c(s)
    }
 }
 
-unrefit_c(s)
-
+void unrefit_c(s)
    char	*s;
 {
    if(!_state.refit_req) return;
@@ -969,7 +958,7 @@ unrefit_c(s)
    _state.planet = NULL;
 }
 
-disengage_c(w, p, s)
+void disengage_c(w, p, s)
    ediswhy		w;
    struct planet	*p;
    char			*s;
@@ -984,8 +973,7 @@ disengage_c(w, p, s)
    _state.ogg_req	= 0;
 }
 
-rdisengage_c(s)
-   
+void rdisengage_c(s)
    char	*s;
 {
    if(!_state.disengage) return;
@@ -997,8 +985,7 @@ rdisengage_c(s)
    _state.lock = 0;
 }
 
-escort_c(p, pl, s)
-
+void escort_c(p, pl, s)
    Player		*p;
    struct planet	*pl;
    char			*s;
@@ -1010,7 +997,7 @@ escort_c(p, pl, s)
    _state.escort = 0;
 }
 
-rescort_c(s)
+void rescort_c(s)
    char	*s;
 {
    if(!_state.escort_req) return;
@@ -1021,8 +1008,7 @@ rescort_c(s)
    _state.escort_planet = NULL;
 }
 
-defend_c(p, s)
-
+void defend_c(p, s)
    Player	*p;
    char	*s;
 {
@@ -1040,8 +1026,7 @@ defend_c(p, s)
    _state.protect_player = p;
 }
 
-rall_c(s)
-   
+void rall_c(s)
    char	*s;
 {
    /*	XX
@@ -1060,8 +1045,7 @@ rall_c(s)
       rdefend_c(s);
 }
 
-rrecharge_c(s)
-
+void rrecharge_c(s)
    char	*s;
 {
    if(!_state.recharge) return;
@@ -1069,8 +1053,7 @@ rrecharge_c(s)
    _state.recharge = 0;
 }
 
-rdefend_c(s)
-
+void rdefend_c(s)
    char	*s;
 {
    if(!_state.defend) return;
@@ -1080,8 +1063,7 @@ rdefend_c(s)
 }
 
 
-decideNotify(com, s, s2)
-
+void decideNotify(com, s, s2)
    char	*com,*s, *s2;
 {
    static char	buf[80];
@@ -1092,12 +1074,11 @@ decideNotify(com, s, s2)
    }
 }
 
-me_closest_to_planet(pl, dist)
-   
+int me_closest_to_planet(pl, dist)
    struct planet	*pl;
    int			dist;
 {
-   register		i;
+   register int		i;
    register Player	*p;
 
    for(i=0, p=_state.players; i < MAXPLAYER; i++,p++){
@@ -1112,12 +1093,11 @@ me_closest_to_planet(pl, dist)
    return 1;
 }
 
-myteam_bombing(pl, dist)
-
+int myteam_bombing(pl, dist)
    struct planet	*pl;
    int			dist;
 {
-   register		i;
+   register int		i;
    register Player	*p;
 
    for(i=0,p=_state.players; i < MAXPLAYER; i++,p++){
@@ -1132,13 +1112,12 @@ myteam_bombing(pl, dist)
    return 0;
 }
 
-pl_defended(pl, c)
-
+int pl_defended(pl, c)
    struct planet	*pl;
    int			c;
 {
    PlanetRec		*pls = _state.planets;
-   register		i, fc=0, ec=0;
+   register	int	i, fc=0, ec=0;
    register	Player	*p;
 
    /* kludge to force bombing if half planets there -- much more important */
@@ -1166,9 +1145,9 @@ pl_defended(pl, c)
    return 0;
 }
 
-pl_attacking()
+int pl_attacking()
 {
-   register		i, ec=0;
+   register	int	i, ec=0;
    register	Player	*p;
    int			m = me->p_no;
 
@@ -1182,8 +1161,7 @@ pl_attacking()
    return ec;
 }
 
-time_to_refit(p)
-   
+int time_to_refit(p)
    Player	*p;
 {
    if(p->dist < 25000 && MYFUEL() > 100)
@@ -1196,9 +1174,9 @@ time_to_refit(p)
    return 1;
 }
 
-check_alldistress()
+void check_alldistress()
 {
-   register		i;
+   register int		i;
    register Player	*p;
 
    if(_state.escort_req || _state.defend)
@@ -1217,11 +1195,10 @@ check_alldistress()
 /* player sent a distress call in the last 15 seconds. Decide to defend or 
    not */
 
-check_distress(p)
-
+int check_distress(p)
    Player	*p;
 {
-   register		i;
+   register int		i;
    register Player	*e;
 
    /* don't get distracted */

--- a/robotd/defaults.c
+++ b/robotd/defaults.c
@@ -19,8 +19,8 @@ struct stringlist *defaults=NULL;
 char *getenv();
 #endif
 
-initDefaults(deffile)
-char *deffile;		/* As opposed to defile? */
+void initDefaults(deffile)
+    char *deffile;		/* As opposed to defile? */
 {
     FILE *fp;
     char file[100];
@@ -65,7 +65,7 @@ char *deffile;		/* As opposed to defile? */
 }
 
 char *getdefault(str)
-char *str;
+    char *str;
 {
     struct stringlist *sl;
 
@@ -79,7 +79,7 @@ char *str;
     return(NULL);
 }
 
-strcmpi(const char * str1, const char * str2)
+int strcmpi(const char * str1, const char * str2)
 {
 /*#ifdef strcasecmp */
     return (strcasecmp(str1,str2));
@@ -99,9 +99,9 @@ strcmpi(const char * str1, const char * str2)
 */
 }
 
-booleanDefault(def, preferred)
-char *def;
-int preferred;
+int booleanDefault(def, preferred)
+    char *def;
+    int preferred;
 {
     char *str;
 

--- a/robotd/disengage.c
+++ b/robotd/disengage.c
@@ -12,7 +12,7 @@
 
 extern unsigned char get_pl_course();
 
-disengage()
+void disengage()
 {
    /* one way to know we are recharging */
    if((me->p_flags & PFORBIT) && !hostilepl(&planets[me->p_planet])){
@@ -62,7 +62,7 @@ disengage()
       disengage_normal();
 }
 
-disengage_defend()
+void disengage_defend()
 {
    Player		*e = _state.closest_e;
    Player		*p = _state.protect_player;
@@ -131,7 +131,7 @@ disengage_defend()
    req_set_speed(speed_r, __LINE__, __FILE__);
 }
 
-disengage_normal()
+void disengage_normal()
 {
    Player		*e = _state.closest_e, *sb, *sb_check();
    struct planet	*pl;
@@ -201,10 +201,9 @@ disengage_normal()
 }
 
 Player *sb_check(dist)
-
    int	*dist;
 {
-   register			i,j, c = 0;
+   register int			i,j, c = 0;
    register Player		*p, *sb = NULL;
 
    *dist = INT_MAX;
@@ -243,8 +242,7 @@ Player *sb_check(dist)
    return sb;
 }
 
-runaway(e)
-
+void runaway(e)
    Player	*e;
 {
    unsigned char	crs, crse, crs_r;
@@ -308,16 +306,14 @@ runaway(e)
    req_set_speed(speed_r, __LINE__, __FILE__);
 }
 
-edistfunc(e, j)
-
+int edistfunc(e, j)
    Player		*e;
    struct player	*j;
 {
    return 10000;
 }
 
-goto_planet(pl)
-
+void goto_planet(pl)
    struct planet	*pl;
 {
    Player		*e = _state.closest_e;
@@ -397,8 +393,7 @@ goto_planet(pl)
  * _state.recharge/_state.disengage, etc. 
  */
 
-handle_disvars(e, speed)
-   
+void handle_disvars(e, speed)
    Player	*e;
    int		*speed;
 {
@@ -473,8 +468,7 @@ handle_disvars(e, speed)
    }
 }
 
-edang(e, r)
-
+int edang(e, r)
    Player	*e;
    int		r;
 {
@@ -490,8 +484,7 @@ edang(e, r)
    return 1;
 }
 
-dng_speed(e)
-
+int dng_speed(e)
    Player	*e;
 {
    int	s = e->p->p_speed;
@@ -518,8 +511,7 @@ dng_speed(e)
 
 /* When to attack player at dangerous speed */
 
-dng_speed_dist(e)
-
+int dng_speed_dist(e)
    Player	*e;
 {
    int	s = e->p->p_speed;
@@ -543,10 +535,8 @@ dng_speed_dist(e)
    return 6000;	/* XX starbase */
 }
 
-recharge_off(s)
-
+void recharge_off(s)
    char	*s;
-
 {
    if(_state.recharge){
       _state.recharge = 0;
@@ -561,7 +551,7 @@ recharge_off(s)
    _state.lock = 0;
 }
 
-reset_planet()
+void reset_planet()
 {
    if(!_state.protect){
       if(!(_state.disengage && _state.diswhy == EREFIT))
@@ -582,12 +572,12 @@ struct {
                 {0, 0},
                 {GWIDTH * 3 / 4, GWIDTH * 3 / 4}};      /* Ori */
 
-home_crs()
+unsigned char home_crs()
 {
    return get_wrapcourse(center[me->p_team].x, center[me->p_team].y);
 }
 
-home_dist()
+int home_dist()
 {
    double	dx = (me->p_x - center[me->p_team].x),
 		dy = (me->p_y - center[me->p_team].y);
@@ -596,12 +586,12 @@ home_dist()
 
 #define NEUTRAL_ZONE	500
 
-in_home_area()
+int in_home_area()
 {
    return in_team_area(me->p_team);
 }
 
-in_team_area(team)
+int in_team_area(team)
    int	team;
 {
    switch(team){
@@ -622,9 +612,9 @@ in_team_area(team)
 }
 
 /* true if we have to go towards enemy home area */
-dangerous_dir(pcrs, r)
-
+int dangerous_dir(pcrs, r)
    unsigned char	pcrs;
+   int			r;
 {
    int			t = _state.warteam;
    unsigned char hcrs = 
@@ -656,7 +646,6 @@ struct planet *team_planet(team)
 }
 
 unsigned char to_team_planet(team)
-
    int	team;
 {
    struct planet *hp = team_planet(team);
@@ -664,7 +653,7 @@ unsigned char to_team_planet(team)
    return get_wrapcourse(hp->pl_x, hp->pl_y);
 }
 
-orbiting_home()
+int orbiting_home()
 {
    struct planet	*h = home_planet();
    if(DEBUG & DEBUG_DISENGAGE){
@@ -676,8 +665,7 @@ orbiting_home()
 
 /* runaway disengage speed */
 
-disengage_speed(e, j, dplanet, pdist)
-
+int disengage_speed(e, j, dplanet, pdist)
    Player		*e;
    struct player	*j;
    int			dplanet;	/* bool */

--- a/robotd/dmessage.c
+++ b/robotd/dmessage.c
@@ -159,16 +159,16 @@ char *version()
    return buf;
 }
 
-dmessage(message,flags,from,to)
-char *message;
-unsigned char flags, from, to;
+void dmessage(message,flags,from,to)
+    char *message;
+    unsigned char flags, from, to;
 {
     /* Message from someone.
       Pass it on to robot for processing */
     R_ProcMessage(message, flags, from, to, 0, 0);
 }
 
-init_comm()
+void init_comm()
 {
    extern	char *commfile;		/* main.c */
    FILE		*fi;
@@ -187,8 +187,8 @@ init_comm()
    fclose(fi);
 }
 
-instr(string1, string2)
-char *string1, *string2;
+int instr(string1, string2)
+    char *string1, *string2;
 {
     char *s;
     int length;
@@ -200,8 +200,7 @@ char *string1, *string2;
     return(0);
 }
 
-R_ProcMessage(message, flags, from, to, std, config)
-
+void R_ProcMessage(message, flags, from, to, std, config)
    char			*message;
    unsigned char	flags, from, to;
    int			std;
@@ -1054,7 +1053,7 @@ R_ProcMessage(message, flags, from, to, std, config)
       }
       else if(strncmp(m, "rwatch", 6)==0){
 	 char	*h = &m[6];
-	 register	i;
+	 register int	i;
 	 while(isspace(*h)) h++;
 	 if(*h){
 	    strcpy(rw_host, h);
@@ -1203,22 +1202,19 @@ R_ProcMessage(message, flags, from, to, std, config)
    }
 }
 
-set_ignore(pno)
-
+void set_ignore(pno)
    int	pno;
 {
    _state.ignore_e[pno] = '1';
 }
 
-set_unignore(pno)
-
+void set_unignore(pno)
    int	pno;
 {
    _state.ignore_e[pno] = '0';
 }
 
-team_int(m)
-
+int team_int(m)
    char	*m;
 {
    if(strncmp(m, "fed", 1)==0){
@@ -1238,7 +1234,6 @@ team_int(m)
 }
 
 char team_bit(m)
-
    char	*m;
 {
    if(strncmp(m, "fed", 1)==0){
@@ -1257,8 +1252,7 @@ char team_bit(m)
       return 0;
 }
 
-team_inttobit(t)
-
+char team_inttobit(t)
    int	t;
 {
    switch(t){
@@ -1270,8 +1264,7 @@ team_inttobit(t)
    }
 }
 
-ship_int(s, name)
-
+int ship_int(s, name)
    char *s, **name;
 {
    if(strncasecmp(s, "scout", 2)==0){
@@ -1306,8 +1299,7 @@ ship_int(s, name)
    return -1;
 }
 
-response(buf)
-
+void response(buf)
    char	*buf;
 {
    if(_state.controller){
@@ -1316,8 +1308,7 @@ response(buf)
    warning(buf, 1);
 }
 
-pmessage(c, buf)
-
+void pmessage(c, buf)
    char	c, *buf;
 {
    int	pno;
@@ -1354,8 +1345,7 @@ pmessage(c, buf)
    }
 }
 
-player_no(c)
-
+int player_no(c)
    char	c;
 {
    if(isdigit(c))
@@ -1365,11 +1355,10 @@ player_no(c)
 }
       
 struct planet *name_to_planet(s, h)
-
    char	*s;
    int	h;
 {
-   register	i;
+   register	int		i;
    register	struct planet	*pl;
    char		buf[32];
    int		l = 3, not_hostile;
@@ -1408,7 +1397,6 @@ struct planet *name_to_planet(s, h)
 }
 
 Player *id_to_player(s, t)
-
    char	*s;
    int	t;
 {
@@ -1433,7 +1421,6 @@ Player *id_to_player(s, t)
 }
 
 eoggtype oggtype(s)
-
    char	*s;
 {
    switch(*s){
@@ -1451,7 +1438,6 @@ eoggtype oggtype(s)
 }
 
 char *oggtype_to_string(ot)
-   
    eoggtype	ot;
 {
    switch(ot){
@@ -1463,7 +1449,6 @@ char *oggtype_to_string(ot)
 }
 
 char *team_to_string(t)
-
    int	t;
 {
    switch(t){
@@ -1477,7 +1462,6 @@ char *team_to_string(t)
 }
 
 char *diswhy_string(e)
-
    ediswhy	e;
 {
    switch(e){
@@ -1493,7 +1477,7 @@ char *diswhy_string(e)
    }
 }
 
-show_serverst()
+void show_serverst()
 {
    mprintf("server: ");
    switch(_server){
@@ -1515,8 +1499,7 @@ show_serverst()
    mprintf("plasma bounce: %s\n", _state.torp_bounce?"true":"false");
 }
 
-handle_generic_req(m)
-   
+void handle_generic_req(m)
    char	*m;
 {
    char	*arg;
@@ -1552,7 +1535,7 @@ handle_generic_req(m)
    sendShortPacket(req_no, arg_no);
 }
 
-list_reqs()
+void list_reqs()
 {
    mprintf("CP_TORP (dir)     : %10d\n", CP_TORP);
    mprintf("CP_PHASER (dir)   : %10d\n", CP_PHASER);
@@ -1572,7 +1555,7 @@ list_reqs()
    mprintf("CP_RESETSTATS 89  : %10d\n", CP_RESETSTATS);
 }
 
-show_state()
+void show_state()
 {
    mprintf("STATE:\n");
    mprintf("%-30s%d\n", "status:", _state.status);
@@ -1676,8 +1659,7 @@ show_state()
    mprintf("%-30s%g\n", "_avsdelay:", _avsdelay);
 }
 
-list_all(m)
-   
+void list_all(m)
    char	*m;
 {
    char	**s = _commands;
@@ -1707,7 +1689,7 @@ list_all(m)
 
 #ifdef ATM
 
-udpaction(com)
+void udpaction(com)
    int	com;
 {
    char		buf[80];
@@ -1776,8 +1758,7 @@ udpaction(com)
 }
 #endif
 
-setlog(dir)
-   
+void setlog(dir)
    char	*dir;
 {
    char	buf[128];
@@ -1794,8 +1775,7 @@ setlog(dir)
    sprintf(buf, "logging (%d)", getpid());
 }
 
-int_var(x, name, desc, in, rnd)
-
+int int_var(x, name, desc, in, rnd)
    int	*x, rnd;
    char	*name, *desc, *in;
 {

--- a/robotd/dodge.c
+++ b/robotd/dodge.c
@@ -41,7 +41,7 @@ struct tpos {
 
 struct tpos _etorps[MAXPLAYER * (MAXTORP+MAXPLASMA) + 1];
 
-init_dodge()
+void init_dodge()
 {
    /* set max speed if damaged */
    set_maxspeed();
@@ -57,10 +57,10 @@ init_dodge()
  * Update enemy torps, friendly damage
  */
 
-init_torps()
+void init_torps()
 {
    int				i;
-   register			k,l;
+   register int			k,l;
    struct player		*j;
    register struct torp		*t;
    register struct tpos		*tp;
@@ -288,7 +288,7 @@ check_plasma:;
    _state.maxfuse = maxfuse;
 }
 
-set_maxspeed()
+void set_maxspeed()
 {
    if(!me->p_damage)
       _state.maxspeed = me->p_ship.s_maxspeed;
@@ -307,14 +307,13 @@ set_maxspeed()
  * Returns number of immediate hits.
  */
 
-compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
-
+void compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
    unsigned char	d_crs, *crs_r;
    int			d_speed, *speed_r, *hittime_r;
    int			*lvorbit;
 {
    static int	r = -1;
-   register	i;
+   register int	i;
    int		hits;
 
    if(!(me->p_flags & PFORBIT) && !(me->p_flags & PFDOCK)){
@@ -427,16 +426,15 @@ compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
 static int chks[4] = { 4, 8, 16, 32 };
 
 /* NOT USED */
-_compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
-
+int _compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
    unsigned char	d_crs, *crs_r;
    int			d_speed, *speed_r, *hittime_r;
    int			lvorbit;
 {
-   register		i;
+   register int		i;
    int			hits;
    int			avdir= -1, hittime, damage;
-   register		mindamage = INT_MAX, cavdir;
+   register int		mindamage = INT_MAX, cavdir;
 
 
    hits = update_torps(&avdir, d_crs, d_speed, &hittime, &damage, lvorbit);
@@ -485,8 +483,7 @@ _compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
       lvorbit);
 }
 
-_try_others(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
-
+int _try_others(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
    unsigned char	d_crs;		/* desired course */
    unsigned char	*crs_r;		/* returned course */
    int			d_speed;	/* desired speed */
@@ -496,7 +493,7 @@ _try_others(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
    int			damage;		/* current damage */
    int			lvorbit;
 {
-   register			i, j;
+   register int			i, j;
    register unsigned char	n_crs;
    register int			dif, dchange, n_speed = d_speed;
    register int			mindamage = damage, hits;
@@ -538,8 +535,7 @@ _try_others(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
 }
 
 /* NOT USED */
-_try_others1(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
-
+int _try_others1(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
    unsigned char	d_crs;		/* desired course */
    unsigned char	*crs_r;		/* returned course */
    int			d_speed;	/* desired speed */
@@ -549,7 +545,7 @@ _try_others1(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
    int			damage;		/* current damage */
    int			lvorbit;
 {
-   register			i, j;
+   register int			i, j;
    register unsigned char	n_crs;
    register int			dif, dchange, n_speed = d_speed;
    register int			mindamage = damage, hits;
@@ -617,8 +613,7 @@ _try_others1(d_crs, crs_r, d_speed, speed_r, hittime_r, cavdir, damage, lvorbit)
    return 1;
 }
 
-update_torps(avdir_r, dir, speed, mintime_r, damage_r, lvorbit)
-   
+int update_torps(avdir_r, dir, speed, mintime_r, damage_r, lvorbit)
    int			*avdir_r;
    unsigned char	dir;		/* desired direction */
    int			speed;		/* desired speed */
@@ -626,10 +621,10 @@ update_torps(avdir_r, dir, speed, mintime_r, damage_r, lvorbit)
    int			*damage_r;	/* amount of damage */
    int			lvorbit;
 {
-   register			i, dx,dy;
+   register int			i, dx,dy;
    register struct tpos		*tp;
    register struct pos		*fp;
-   register			cx = me->p_x, cy = me->p_y;
+   register int			cx = me->p_x, cy = me->p_y;
    int				mx,my, damage;
    int				ddist, minhittime, hits,
 				tdamage, expdist;
@@ -764,8 +759,7 @@ update_torps(avdir_r, dir, speed, mintime_r, damage_r, lvorbit)
    return hits;
 }
 
-torp_seek_ship(s)
-
+int torp_seek_ship(s)
    int	s;
 {
    if(!_state.torp_seek) return 0;
@@ -779,8 +773,7 @@ torp_seek_ship(s)
    }
 }
 
-accavdir(avdir, damage, tdir, tdamage)
-
+int accavdir(avdir, damage, tdir, tdamage)
    int	avdir;		/* original direction average */
    int	damage;		/* damage to be associated with avdir */
    unsigned char tdir;	/* torp direction */
@@ -803,7 +796,7 @@ accavdir(avdir, damage, tdir, tdamage)
    return NORMALIZE(av);
 }
 
-initppos()
+void initppos()
 {
    _myspeed = me->p_speed;
    _mydir = me->p_dir;
@@ -812,9 +805,8 @@ initppos()
    _cticks = 1;
 }
 
-getppos(cx,cy, rx, ry, dir, speed, lvorbit)
-
-   register		cx,cy;
+void getppos(cx, cy, rx, ry, dir, speed, lvorbit)
+   register int		cx, cy;
    int			*rx, *ry;
    unsigned char	dir;
    int			speed;
@@ -904,12 +896,11 @@ getppos(cx,cy, rx, ry, dir, speed, lvorbit)
    _cticks++;
 }
 
-getorbit_ppos(cx,cy, rx, ry)
-
-   register		cx,cy;
+void getorbit_ppos(cx, cy, rx, ry)
+   register int		cx, cy;
    int			*rx, *ry;
 {
-   register		px,py;
+   register int		px, py;
 
 #ifdef nodef
    if(_state.planet && (&planets[me->p_planet] != _state.planet)){
@@ -926,9 +917,9 @@ getorbit_ppos(cx,cy, rx, ry)
    *ry = py+ORBDIST * Sin[(unsigned char)(_mydir - (unsigned char) 64)];
 }
 
-update_hplanets()
+void update_hplanets()
 {
-   register                     i;
+   register int                 i;
    register struct planet       *pl;
    double                       dx,dy;
    register int                 pdist, mindist = INT_MAX;
@@ -964,8 +955,7 @@ update_hplanets()
 #endif 
 }
 
-
-fixfuse(tx,ty, tf, j, tdx, tdy)
+void fixfuse(tx,ty, tf, j, tdx, tdy)
    int			tx,ty;
    int                  *tf;
    struct player        *j;
@@ -984,8 +974,7 @@ fixfuse(tx,ty, tf, j, tdx, tdy)
 }
  
 /* xx */
-c_lookahead(v)
-
+void c_lookahead(v)
    int	v;
 {
    static int	prevf;
@@ -998,8 +987,8 @@ c_lookahead(v)
       _state.lookahead = prevf;
 }
 
-set_lookahead(v, b)
-   int	v;
+void set_lookahead(v, b)
+   int	v, b;
 {
    static int	prevf;
    if(b){
@@ -1018,13 +1007,12 @@ set_lookahead(v, b)
  
  
 #define MINDIST		3700
-check_gboundary(mycrs, range)
- 
+void check_gboundary(mycrs, range)
    unsigned char        *mycrs;
    int			range;
 {
    int  			l = 0, r = 0;
-   register			x = me->p_x, y = me->p_y;
+   register int			x = me->p_x, y = me->p_y;
    register unsigned char	crs = *mycrs;
  
    if(x < MINDIST && crs > 128){
@@ -1056,12 +1044,11 @@ check_gboundary(mycrs, range)
    }
 }
  
-init_ftorps(i, j)
-
+void init_ftorps(i, j)
    int                  i;
    struct player        *j;
 {
-   register             k;
+   register int         k;
    register struct torp *t;
 
    for(k=0, t= &torps[i*MAXTORP] ; k < MAXTORP; k++, t++){
@@ -1082,8 +1069,7 @@ init_ftorps(i, j)
    }
 }
 
-init_phasers(p, j, ph)
- 
+void init_phasers(p, j, ph)
    Player               *p;
    struct player        *j;
    struct phaser        *ph;
@@ -1095,8 +1081,7 @@ init_phasers(p, j, ph)
    p->wpntemp += (SH_PHASERCOST(j)/10);
 }
 
-do_phaserdamage(p, j, ph)
-
+void do_phaserdamage(p, j, ph)
    Player               *p;
    struct player        *j;
    struct phaser        *ph;
@@ -1137,14 +1122,13 @@ do_phaserdamage(p, j, ph)
    }
 }
 
-do_plasmadamage(po, jo, pt)
-
+void do_plasmadamage(po, jo, pt)
    Player               *po;
    struct player        *jo;
    struct plasmatorp	*pt;
 {
-   register 			i;
-   register 			dx,dy,dist;
+   register int			i;
+   register int			dx, dy, dist;
    int			  	damage, pldamage;
    register struct player 	*j;
    register Player		*p;
@@ -1181,13 +1165,12 @@ do_plasmadamage(po, jo, pt)
    }
 }
 
-check_damage(enemy, t, td)
-
+void check_damage(enemy, t, td)
    int		enemy;
    struct torp  *t;
    int          td;
 {
-   register             i;
+   register int         i;
    register Player     *p;
    for(i=0, p=_state.players; i< MAXPLAYER; i++, p++){
       if(p->p && !p->invisible){
@@ -1198,13 +1181,12 @@ check_damage(enemy, t, td)
    }
 }
  
-check_dettorps(t,k)
-
+void check_dettorps(t, k)
    struct torp  *t;
    int          k;
 {
    Player		*ct = _state.current_target;
-   register             x = 0, y = 0;
+   register int         x = 0, y = 0;
    unsigned char        tdir, hcrs = 0;
    double		dx,dy;
 
@@ -1294,7 +1276,7 @@ check_dettorps(t,k)
    }
 
    if(_state.human || detall){
-      register	h;
+      register int	h;
       register struct torp	*l;
       for(h=0,l= &torps[MAXTORP*me->p_no]; h< me->p_ntorp; h++,l++){
 	 if(!l->t_shoulddet)
@@ -1306,8 +1288,7 @@ check_dettorps(t,k)
    }
 }
 
-cloaked(p)
-
+int cloaked(p)
    Player	*p;
 {
    if(!p || !p->p || !isAlive(p->p))
@@ -1318,13 +1299,13 @@ cloaked(p)
 unsigned char get_new_course1();
 unsigned char get_new_course2();
 unsigned char get_new_course3();
-_old_compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
 
+int _old_compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
    unsigned char        d_crs, *crs_r;
    int                  d_speed, *speed_r, *hittime_r;
    int			*lvorbit;
 {
-   register             i, nh;
+   register int         i, nh;
    int                  hittime, minhits = INT_MAX, minhittime = INT_MAX,
                         mindamage = INT_MAX,
 #ifdef nodef
@@ -1491,7 +1472,6 @@ _old_compute_course(d_crs, crs_r, d_speed, speed_r, hittime_r, lvorbit)
 }
 
 unsigned char get_new_course1(avdir, hittime, d_crs, it)
-
    int                  avdir, hittime, it;
    unsigned char        d_crs;
 {
@@ -1506,7 +1486,6 @@ unsigned char get_new_course1(avdir, hittime, d_crs, it)
 }
 
 unsigned char get_new_course2(avdir, hittime, dc, i)
-
    int                  avdir;
    int			hittime;
    unsigned char        dc;
@@ -1523,7 +1502,6 @@ unsigned char get_new_course2(avdir, hittime, dc, i)
 
 /* for _state.human */
 unsigned char get_new_course3(avdir, hittime, dc, i)
-
    int                  avdir;
    int			hittime;
    unsigned char        dc;
@@ -1554,8 +1532,7 @@ unsigned char get_new_course3(avdir, hittime, dc, i)
    }
 }
 
-mod_torp_speed(pdir, pspeed, tdir, tspeed)
-   
+int mod_torp_speed(pdir, pspeed, tdir, tspeed)
    unsigned char	pdir,tdir;
    int			pspeed, tspeed;
 {
@@ -1580,14 +1557,13 @@ mod_torp_speed(pdir, pspeed, tdir, tspeed)
    return newspeed;
 }
 
-check_server_response(x, y, cycles, e, j)
-
+void check_server_response(x, y, cycles, e, j)
    int                  *x,*y;
    int			cycles;
    Player		*e;
    struct player	*j;
 {
-   register             i;
+   register int         i;
    int                  accint = SH_ACCINT(me),
                         decint = SH_DECINT(me),
                         turns = SH_TURNS(me),
@@ -1665,8 +1641,7 @@ check_server_response(x, y, cycles, e, j)
    }
 }
 
-add_tractor(e, j, x, y, cycles)
-
+void add_tractor(e, j, x, y, cycles)
    Player		*e;
    struct player	*j;
    int			*x,*y;
@@ -1683,8 +1658,7 @@ add_tractor(e, j, x, y, cycles)
    tp_change(me, e->p, dist, 1, x, y, &dm, &dm);
 }
 
-add_pressor(e, j, x, y)
-
+void add_pressor(e, j, x, y)
    Player		*e;
    struct player	*j;
    int			*x,*y;
@@ -1694,8 +1668,7 @@ add_pressor(e, j, x, y)
    tp_change(me, e->p, e->dist, -1, x, y, &dm, &dm);
 }
 
-add_mytractor(x, y)
-
+void add_mytractor(x, y)
    int	*x,*y;
 {
    struct player	*j = &players[me->p_tractor];
@@ -1710,8 +1683,7 @@ add_mytractor(x, y)
    tp_change(j, me, dist, 1, x, y, &dm, &dm);
 }
 
-add_mypressor(x, y)
-
+void add_mypressor(x, y)
    int	*x,*y;
 {
    struct player	*j = &players[me->p_tractor];
@@ -1728,8 +1700,7 @@ add_mypressor(x, y)
 
 
 /* j2 -- tractor, j1 -- tractee */
-tp_change(j1, j2, dist, dir, x, y, hx, hy)
-
+void tp_change(j1, j2, dist, dir, x, y, hx, hy)
    struct player 	*j1, *j2;
    int			dist, dir;
    int			*x,*y;		/* change to j1 */
@@ -1758,8 +1729,7 @@ tp_change(j1, j2, dist, dir, x, y, hx, hy)
    *y -= dir * sinTheta * halfforce/(SH_MASS(j2));
 }
 
-predict_pltorp(j, pt_dir, pt_x, pt_y, mx,my)
-   
+void predict_pltorp(j, pt_dir, pt_x, pt_y, mx,my)
    struct player	*j;		/* ptorp owner */
    unsigned char	*pt_dir;	/* torp direction */
    int			*pt_x, *pt_y;	/* ptorp position */
@@ -1790,8 +1760,7 @@ predict_pltorp(j, pt_dir, pt_x, pt_y, mx,my)
    *pt_y += (double) j->p_ship.s_plasmaspeed * Sin[*pt_dir] * WARP1;
 }
 
-predict_storp(j, pt_dir, pt_x, pt_y, mx,my)
-   
+void predict_storp(j, pt_dir, pt_x, pt_y, mx,my)
    struct player	*j;		/* ptorp owner */
    unsigned char	*pt_dir;	/* torp direction */
    int			*pt_x, *pt_y;	/* ptorp position */
@@ -1817,7 +1786,8 @@ predict_storp(j, pt_dir, pt_x, pt_y, mx,my)
 
 unsigned char
 get_bearing(xme, yme, x, y, dir)
-int x, y;
+  int xme, yme, x, y;
+  int dir;
 {
   int phi=0;
 
@@ -1829,4 +1799,3 @@ int x, y;
   else
     return((unsigned char) (256 + phi - dir));
 }
-

--- a/robotd/engage.c
+++ b/robotd/engage.c
@@ -14,8 +14,7 @@ unsigned char choose_ecourse();
 
 /* called from s_target in robot.c */
 
-engage(e)
-
+void engage(e)
    Player		*e;
 {
    /* right place? */
@@ -29,7 +28,7 @@ engage(e)
       pengage(e);
 }
 
-plengage()
+void plengage()
 {
    Player		*e;
    unsigned char	crs = _state.p_desdir, crs_r;
@@ -111,8 +110,7 @@ plengage()
       pengage(e);
 }
 
-dengage(e)
-
+void dengage(e)
    Player	*e;
 {
    unsigned char	crs = _state.p_desdir, crs_r;
@@ -218,8 +216,7 @@ dengage(e)
       pengage(e);
 }
 
-pengage(e)
-
+void pengage(e)
    Player	*e;
 {
    int			edist, e_dist;
@@ -276,8 +273,7 @@ pengage(e)
    req_set_speed(speed_r, __LINE__, __FILE__);
 }
 
-goto_protect(pl, p, dock)
-   
+void goto_protect(pl, p, dock)
    struct planet	*pl;
    Player		*p;
    int			dock;
@@ -410,10 +406,8 @@ goto_protect(pl, p, dock)
    }
 }
 
-
 /* enemy */
 Player	*get_nearest_to_pl(pl)
-
    struct planet	*pl;
 {
    Player *get_nearest_to_pl_dist();
@@ -446,7 +440,6 @@ Player *get_nearest_to_pl_dist(pl, rdist)
 }
 
 Player *get_nearest_to_p(p, d)
-
    Player	*p;
    int		*d;
 {
@@ -473,16 +466,14 @@ Player *get_nearest_to_p(p, d)
 }
 
 /* make sure  */
-hostilepl(pl)
-
+int hostilepl(pl)
    struct planet	*pl;
 {
    return (me->p_team != pl->pl_owner) &&
       ((me->p_swar | me->p_hostile) & pl->pl_owner);
 }
 
-unknownpl(pl)
-
+int unknownpl(pl)
    struct planet	*pl;
 {
    if(!pl) return 0;
@@ -491,11 +482,10 @@ unknownpl(pl)
 
 /* likely team for unknown planet */
 
-team_areapl(pl)
-
+int team_areapl(pl)
    struct planet	*pl;
 {
-   register	x = pl->pl_x, y = pl->pl_y;
+   register int	x = pl->pl_x, y = pl->pl_y;
 
    if(!unknownpl(pl))
       return pl->pl_owner;
@@ -509,8 +499,7 @@ team_areapl(pl)
 }
 
 /* unknown planet -- guess what team it is */
-guess_team(pl)
-
+int guess_team(pl)
    struct planet	*pl;
 {
    int	plteam = team_areapl(pl);
@@ -526,7 +515,7 @@ guess_team(pl)
    return team;
 }
 
-war_team()
+int war_team()
 {
    switch(me->p_team){
       case FED:
@@ -552,9 +541,7 @@ war_team()
    return FED;
 }
 
-
-alter_course_distance(e, e_dist, crs)
-
+void alter_course_distance(e, e_dist, crs)
    Player		*e;
    int			e_dist;
    unsigned char	*crs;
@@ -650,8 +637,7 @@ alter_course_distance(e, e_dist, crs)
    }
 }
 
-mod_fight_dist(e)
-
+int mod_fight_dist(e)
    Player	*e;
 {
    int	sh	= me->p_ship.s_type;
@@ -722,7 +708,6 @@ mod_fight_dist(e)
 }
 
 unsigned char choose_ecourse(p, j, edist)
-
    Player		*p;
    struct player	*j;
    int			edist;
@@ -761,8 +746,7 @@ unsigned char choose_ecourse(p, j, edist)
 #define EDGE_DIST	20000
 
 /* Try to force player into the edge */
-edge_course(j, edist, crs)
-
+void edge_course(j, edist, crs)
    struct player	*j;
    int			edist;
    unsigned char	*crs;
@@ -776,8 +760,7 @@ edge_course(j, edist, crs)
 }
 
 /* based on get_torp_course */
-get_intercept_course(p, j, edist, crs)
-
+int get_intercept_course(p, j, edist, crs)
    Player		*p;
    struct player	*j;
    int			edist;

--- a/robotd/enter.c
+++ b/robotd/enter.c
@@ -21,7 +21,7 @@ long random();
 /* Doesn't really openmem, but it will
  * set some stuff up...
  */
-openmem()
+void openmem()
 {
     int i;
 

--- a/robotd/escort.c
+++ b/robotd/escort.c
@@ -16,7 +16,7 @@
 static int	_esc_dist;
 
 /* escort player to planet */
-escort()
+void escort()
 {
    Player		*escp  = _state.escort_player;
    struct planet 	*escpl = _state.escort_planet;
@@ -104,8 +104,7 @@ escort()
  */
 
 /* 0 */
-goto_escort_planet(p, pl)
-   
+void goto_escort_planet(p, pl)
    Player		*p;
    struct planet	*pl;
 {
@@ -139,8 +138,7 @@ goto_escort_planet(p, pl)
 }
 
 /* 1 */
-wait_for_escort(p, pl)
-   
+void wait_for_escort(p, pl)
    Player		*p;
    struct planet	*pl;
 {
@@ -186,8 +184,7 @@ wait_for_escort(p, pl)
 }
 
 /* 2 */
-goto_defender(p, pl)
-   
+void goto_defender(p, pl)
    Player		*p;
    struct planet	*pl;
 {
@@ -214,8 +211,7 @@ goto_defender(p, pl)
 }
 
 /* 3 */
-ogg_defender(p, pl)
-
+void ogg_defender(p, pl)
    Player		*p;
    struct planet	*pl;
 {
@@ -244,12 +240,11 @@ ogg_defender(p, pl)
 /* UNUSED */
 /* the further away the player is the more likely to be an interference. */
 
-find_interference(ie, d)
-
+int find_interference(ie, d)
    Player	*ie[MAXPLAYER];	/* used */
    int		d;
 {
-   register		i, j=0;
+   register int		i, j=0;
    register Player	*p;
 
    for(i=0, p=_state.players; i< MAXPLAYER; i++,p++){
@@ -262,8 +257,7 @@ find_interference(ie, d)
    return j;
 }
 
-on_my_course(p)
-
+int on_my_course(p)
    Player	*p;
 {
    unsigned char	mycrs = _state.p_desdir;
@@ -272,7 +266,7 @@ on_my_course(p)
    return angdist(mycrs, ecrs) < 16;
 }
 
-do_course_speed(crs, speed)
+void do_course_speed(crs, speed)
    unsigned char	crs;
    int			speed;
 {

--- a/robotd/findslot.c
+++ b/robotd/findslot.c
@@ -16,7 +16,7 @@
 #include "struct.h"
 #include "data.h"
 
-findslot()
+void findslot()
 {
     int oldcount= -1;
 

--- a/robotd/getarmies.c
+++ b/robotd/getarmies.c
@@ -17,9 +17,9 @@ struct planet *find_army_planet();
 
 /* get armies */
 
-getarmies()
+void getarmies()
 {
-   register			i;
+   register int			i;
    register struct planet	*pl;
    struct planet		*aspl = _state.assault_planet;
    struct planet		*apl = _state.army_planet;
@@ -79,8 +79,7 @@ getarmies()
 }
 
 /* UNUSED */
-goto_armypl(pl)
-
+void goto_armypl(pl)
    struct	planet	*pl;
 {
    Player		*e = _state.closest_e;
@@ -156,8 +155,7 @@ goto_armypl(pl)
    }
 }
 
-beam_up_armies(pl)
-   
+void beam_up_armies(pl)
    struct planet	*pl;
 {
    int		armies = pl->pl_armies;
@@ -179,8 +177,7 @@ beam_up_armies(pl)
    }
 }
 
-troop_capacity(j)
-   
+int troop_capacity(j)
    struct player	*j;
 {
    if (j->p_ship.s_type == ASSAULT)
@@ -193,12 +190,10 @@ troop_capacity(j)
       return j->p_ship.s_maxarmies;
 }
 
-
-others_taking_armies(pl)
-
+int others_taking_armies(pl)
    struct planet	*pl;
 {
-   register			i;
+   register int			i;
    register Player		*p;
    register struct player	*j;
 
@@ -220,10 +215,9 @@ others_taking_armies(pl)
 }
 
 struct planet *find_army_planet(pl)
-
    struct planet	*pl;
 {
-   register			i;
+   register int			i;
    register struct planet	*k, *mp = NULL;
    int				mdist = INT_MAX, pdist, hdist;
    Player			*p, *get_nearest_to_pl_dist();
@@ -267,8 +261,7 @@ struct planet *find_army_planet(pl)
    return mp;
 }
 
-orbiting(pl)
-
+int orbiting(pl)
    struct planet	*pl;
 {
    if(!pl){
@@ -278,7 +271,7 @@ orbiting(pl)
    return (me->p_flags & PFORBIT) && me->p_planet == pl->pl_no;
 }
 
-need_armies()
+int need_armies()
 {
    int	tarmy;
 
@@ -293,8 +286,7 @@ need_armies()
    return me->p_armies < tarmy;
 }
 
-notify_take(aspl, phase)
-   
+void notify_take(aspl, phase)
    struct planet	*aspl;
    int			phase;
 {

--- a/robotd/getname.c
+++ b/robotd/getname.c
@@ -18,7 +18,7 @@
 #include "struct.h"
 #include "data.h"
 
-renter(pseudo, pss, log)
+void renter(pseudo, pss, log)
    char           *pseudo, *pss, *log;
 {
    int		   guest = (strcmp(pseudo, "guest") == 0);

--- a/robotd/getship.c
+++ b/robotd/getship.c
@@ -13,11 +13,11 @@
 
 /* fill in ship characteristics */
 
-getship(shipp, s_type)
-struct ship *shipp;
-int s_type;
+void getship(shipp, s_type)
+    struct ship *shipp;
+    int s_type;
 {
-    register i=0;
+    register int i = 0;
     
     if(!_state.chaos){
 	switch (s_type) {
@@ -657,5 +657,4 @@ int s_type;
 	}
     }
 }
-
 

--- a/robotd/input.c
+++ b/robotd/input.c
@@ -38,7 +38,7 @@ int	recflag = 0;
  * Function may still break if unix super-user executes 
  * set-time-of-day function, via unix command. 
  */ 
-setflag()
+void setflag()
 {
    static int start=0; /* start of the robot program */
    static int cycle=0; /* how many times udtime cycles */
@@ -69,7 +69,7 @@ setflag()
 
 }
 
-input()
+void input()
 {
 #ifdef nodef
    struct itimerval	udt;
@@ -108,7 +108,7 @@ input()
 
 static char	_buf[80];
 
-process_stdin()
+void process_stdin()
 {
    struct timeval	timeout;
    fd_set		readfd;

--- a/robotd/main.c
+++ b/robotd/main.c
@@ -34,7 +34,7 @@ static   int    first = 1;
 jmp_buf         env;
 char	*commfile = NULL;
 
-main(argc, argv)
+int main(argc, argv)
    int             argc;
    char          **argv;
 {
@@ -43,11 +43,11 @@ main(argc, argv)
    int             usage = 0;
    int             err = 0;
    char           *name, *ptr, *cp, *rindex();
-   int             dcore(), resetRobot();
+   void            dcore(), resetRobot();
    void            reaper(int), kill_rwatch(int), exitRobot(int);
    int             passive = 0;
    char           *defaultsFile = NULL;
-   register        i;
+   register int    i;
    int             rwatch=0;
    static int      switchedteams=0;
    char            password[64];
@@ -481,9 +481,11 @@ main(argc, argv)
    }
 
    input();
+
+   return 0;
 }
 
-printUsage(prog)
+void printUsage(prog)
    char           *prog;
 {
    static char *list[] = {
@@ -563,14 +565,14 @@ void exitRobot(int sig)
    }
 }
 
-resetRobot()
+void resetRobot()
 {
    fprintf(stderr, "BUS or SEGV\n");
    _state.command = C_RESET;
    longjmp(env,0);
 }
 
-dcore()
+void dcore()
 {
    abort();
 }
@@ -585,7 +587,7 @@ void kill_rwatch(int sig)
    /* exit otherwise? */
 }
 
-getteam()
+int getteam()
 {
    int	nf= -1, nk= -1, nr= -1, no= -1;
 

--- a/robotd/master.c
+++ b/robotd/master.c
@@ -20,13 +20,13 @@
 #include "packets.h"
 #include "robot.h"
 
-master()
-{}
+void master()
+{
+}
 
 /* slave robot */
 
-connect_master(m)
-
+int connect_master(m)
    char	*m;
 {
    int			v, ms = -1;
@@ -74,8 +74,7 @@ connect_master(m)
 
 /* slave sends master packets */
 
-send_to_master(p, s)
-   
+void send_to_master(p, s)
    struct player_spacket	*p;
    int				s;
 {
@@ -88,8 +87,7 @@ send_to_master(p, s)
    }
 }
 
-recv_from_master(p)
-
+void recv_from_master(p)
    struct mastercomm_spacket	*p;
 {
 }

--- a/robotd/newwin.c
+++ b/robotd/newwin.c
@@ -18,8 +18,8 @@
 #include "packets.h"
 
 /* Attempt to pick specified team & ship */
-teamRequest(team, ship) 
-int team,ship;
+int teamRequest(team, ship) 
+    int team,ship;
 {
     int lastTime;
 
@@ -62,13 +62,14 @@ int team,ship;
     return(pickOk);
 }
 
-showteams()
+void showteams()
 {
    mprintf("FED: %d, ROM: %d, KLI: %d, ORI: %d\n",
       numShips(FED), numShips(ROM), numShips(KLI), numShips(ORI));
 }
 
-numShips(owner)
+int numShips(owner)
+	int		owner;
 {
 	int		i, num = 0;
 	struct player	*p;
@@ -79,7 +80,8 @@ numShips(owner)
 	return (num);
 }
 
-realNumShips(owner)
+int realNumShips(owner)
+	int		owner;
 {
 	int		i, num = 0;
 	struct player	*p;
@@ -91,8 +93,8 @@ realNumShips(owner)
 	return (num);
 }
 
-deadTeam(owner)
-int owner;
+int deadTeam(owner)
+    int owner;
 /* The team is dead if it has no planets and cannot coup it's home planet */
 {
     int i,num=0;
@@ -108,7 +110,7 @@ int owner;
     return(1);
 }
 
-do_refit(type)
+void do_refit(type)
     int type;
 {	
     sendRefitReq(type);

--- a/robotd/ogg.c
+++ b/robotd/ogg.c
@@ -20,7 +20,7 @@ static int 	odist;
 
 /* actual firing doesn't occur until _state.ogg = 1 */
 
-ogg()
+void ogg()
 {
    Player	*e = _state.current_target;
    int		p;
@@ -87,7 +87,7 @@ ogg()
    }
 }
 
-friend_uncloak(e_num)
+int friend_uncloak(e_num)
    int	e_num;
 {
    Player		*p = _state.closest_f;
@@ -102,8 +102,7 @@ friend_uncloak(e_num)
    return 0;
 }
 
-goto_ogg(e)
-
+void goto_ogg(e)
    Player	*e;
 {
    unsigned char	crs, crs_r, ogg_course();
@@ -190,7 +189,6 @@ goto_ogg(e)
 }
 
 unsigned char ogg_course(o, c)
-
    Player	*o;
    int		*c;
 {
@@ -264,7 +262,6 @@ unsigned char ogg_course(o, c)
 }
 
 unsigned char ocourse(o)
-   
    Player	*o;
 {
    int	r, dist;
@@ -274,7 +271,6 @@ unsigned char ocourse(o)
    if(j->p_ship.s_type != STARBASE){
       return (unsigned char) ((int)o->icrs);
    }
-
 
    if(!ogg_state){
       int	a;
@@ -316,7 +312,6 @@ unsigned char ocourse(o)
 }
 
 int modspeed(sp, p, e)
-   
    int		sp;
    Player	*p, *e;
 {
@@ -366,7 +361,7 @@ int modspeed(sp, p, e)
    1: uncloak
  */
 
-wait_on_sync()
+int wait_on_sync()
 {
    Player	*p;
    static int	timer;
@@ -396,7 +391,7 @@ wait_on_sync()
 
 unsigned char	ogg_incoming_dir = 0;
 
-set_ogg_vars()
+void set_ogg_vars()
 {
    int			r;
    Player		*e = _state.current_target;

--- a/robotd/parse.c
+++ b/robotd/parse.c
@@ -16,8 +16,7 @@
 
 static struct planet *_find_planet_by_name();
 
-parse_message(m, p, fl)
-
+void parse_message(m, p, fl)
    char		*m;
    Player	*p;
    int		fl;
@@ -35,8 +34,7 @@ parse_message(m, p, fl)
    proc_other(p, m);
 }
 
-proc_distress_call(p, m)
-
+void proc_distress_call(p, m)
    Player	*p;
    char		*m;
 {
@@ -86,8 +84,7 @@ proc_distress_call(p, m)
       check_distress(p);
 }
 
-proc_other(p, m)
-   
+void proc_other(p, m)
    Player	*p;
    char		*m;
 {
@@ -98,8 +95,7 @@ proc_other(p, m)
    /* ... */
 }
 
-proc_hostile_planet_mesg(p, m)
-   
+void proc_hostile_planet_mesg(p, m)
    Player	*p;
    char		*m;
 {
@@ -133,8 +129,7 @@ proc_hostile_planet_mesg(p, m)
    }
 }
 
-check_hostile_planet_word(p, w)
-
+int check_hostile_planet_word(p, w)
    Player	*p;
    char		*w;
 {
@@ -150,7 +145,6 @@ check_hostile_planet_word(p, w)
    
    if(me->p_armies > 0 || (inl && me->p_kills >= 2.0))
       return;
-   
    
    if(pl){
 
@@ -179,15 +173,14 @@ check_hostile_planet_word(p, w)
       return 0;
 }
 
-inl_prot()
+int inl_prot()
 {
    if(inl && _state.planets->num_teamsp > 3 && _state.protect)
       return 1;
    return 0;
 }
 
-rndesc(p)
-   
+int rndesc(p)
    Player	*p;
 {
    int		armies;
@@ -212,10 +205,8 @@ rndesc(p)
    mprintf("rndesc: unknown\n");
    return 0;
 }
-      
 
-ship_match(p)
-   
+int ship_match(p)
    Player	*p;
 {
    if(!p || !p->p || !isAlive(p->p))
@@ -246,9 +237,9 @@ ship_match(p)
    return 0;
 }
 
-init_plarray()
+void init_plarray()
 {
-   register	i;
+   register int	i;
    char 	*short_name();
    int		plcmp_long();
 
@@ -272,7 +263,6 @@ init_plarray()
  */
 
 struct planet *find_planet_by_shortname(n, f)
-
    char	*n;
    int	f;	/* for short names -- look for friendly or hostile */
 {
@@ -306,7 +296,6 @@ struct planet *find_planet_by_shortname(n, f)
  */
 
 struct planet *find_planet_by_longname(n)
-
    char	*n;
 {
    struct planet	*p;
@@ -323,7 +312,6 @@ struct planet *find_planet_by_longname(n)
 }
 
 static struct planet *_find_planet_by_name(n, l, d)
-
    char	*n;
    int	l;
    int	d;
@@ -352,22 +340,19 @@ static struct planet *_find_planet_by_name(n, l, d)
    return r->pm_planet;
 }
 
-plcmp_short(p1, p2)
-
+int plcmp_short(p1, p2)
    struct planetmatch	*p1, *p2;
 {
    return strcmp(p1->pm_short, p2->pm_short);
 }
 
-plcmp_long(p1, p2)
-
+int plcmp_long(p1, p2)
    struct planetmatch	*p1, *p2;
 {
    return strcmp(p1->pm_name, p2->pm_name);
 }
 
 char *short_name(pl)
-
    struct planet        *pl;
 {
    char         *n = pl->pl_name;
@@ -393,7 +378,6 @@ char *short_name(pl)
 }
 
 char *short_name_print(pl)
-
    struct planet        *pl;
 {
    char         *n = pl->pl_name;
@@ -411,8 +395,7 @@ char *short_name_print(pl)
    return sname;
 }
 
-esc_too_far(p, pl)
-   
+int esc_too_far(p, pl)
    Player		*p;
    struct planet	*pl;
 {
@@ -426,8 +409,7 @@ esc_too_far(p, pl)
       return pl->pl_mydist > dist_to_planet(p, pl) - 3000;
 }
 
-his_ship_faster(p)
-
+int his_ship_faster(p)
    Player	*p;
 {
    int	sh, sm;
@@ -536,8 +518,7 @@ his_ship_faster(p)
    return 0; /* xx */
 }
 
-get_distress(m, dam, shield, arm, wpn, woe, eoe)
-   
+void get_distress(m, dam, shield, arm, wpn, woe, eoe)
    char	*m;
    int	*dam,*shield,*arm,*wpn, *woe, *eoe;
 {

--- a/robotd/ping.c
+++ b/robotd/ping.c
@@ -25,7 +25,7 @@ static int	ping_sd=0;	/* std deviation */
 static int	sum, n, s2;
 static int	M, var;
 
-handlePing(packet)                         /* SP_PING */
+void handlePing(packet)                         /* SP_PING */
    struct ping_spacket *packet;
 { 
    ping = 1;		/* we got a ping */
@@ -43,7 +43,7 @@ printf("ping received at %d (lag: %d)\n", msetime(), (int)packet->lag);
    calc_lag();
 }
 
-startPing()
+void startPing()
 {
    static
    struct ping_cpacket 	packet;
@@ -59,7 +59,7 @@ startPing()
    }
 }
 
-stopPing()
+void stopPing()
 {
    static
    struct ping_cpacket 	packet;
@@ -75,8 +75,7 @@ stopPing()
    }
 }
    
-
-sendServerPingResponse(number)     	/* CP_PING_RESPONSE */
+void sendServerPingResponse(number)     	/* CP_PING_RESPONSE */
    int number;
 {
    struct ping_cpacket 	packet;
@@ -108,7 +107,7 @@ printf("ping response sent at %d\n", msetime());
    }
 }
 
-calc_lag()
+void calc_lag()
 {
 #ifdef nodef
    /* probably ghostbusted */

--- a/robotd/pwarfare.c
+++ b/robotd/pwarfare.c
@@ -14,13 +14,11 @@ static int	_special_tr;
 
 #define PDEFEND	(_state.defend || _state.player_type == PT_DEFENDER)
 
-pwarfare(type, e, j, edist)
-
+void pwarfare(type, e, j, edist)
    int			type;
    Player		*e;
    struct player	*j;
    int			edist;
-   
 {
    if(_state.ignore_sudden && should_ignore(e,j,edist)){
       return;
@@ -108,8 +106,7 @@ pwarfare(type, e, j, edist)
    }
 }
 
-should_ignore(e,j,edist)
-   
+int should_ignore(e,j,edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -120,13 +117,12 @@ should_ignore(e,j,edist)
    return 0;
 }
 
-ttime()
+int ttime()
 {
    return (_udcounter - _timers.tractor_time) >= _timers.tractor_limit;
 }
 
-handle_tractors(e, j, edist, tractor, s, m)
-
+void handle_tractors(e, j, edist, tractor, s, m)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -158,8 +154,7 @@ handle_tractors(e, j, edist, tractor, s, m)
    }
 }
 
-check_pressor(e)
-
+void check_pressor(e)
    Player	*e;
 {
    struct player	*j;
@@ -188,8 +183,7 @@ check_pressor(e)
    }
 }
    
-ptorp_attack(e, j, edist)
-
+void ptorp_attack(e, j, edist)
    Player		*e;
    struct player 	*j;
    int			edist;
@@ -577,8 +571,7 @@ ptorp_attack(e, j, edist)
    }
 }
 
-plasma_attack(e,j,edist)
-
+void plasma_attack(e,j,edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -606,7 +599,7 @@ plasma_attack(e,j,edist)
    }
 }
 
-have_plasma()
+int have_plasma()
 {
    if(_state.chaos){
       switch(me->p_ship.s_type){
@@ -626,8 +619,7 @@ have_plasma()
       return _state.have_plasma;
 }
 
-pphaser_attack(e, j, edist)
-
+void pphaser_attack(e, j, edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -795,8 +787,7 @@ pphaser_attack(e, j, edist)
    }
 }
 
-active(p)
-
+int active(p)
    Player	*p;
 {
    if(!p || !p->p || !isAlive(p->p) || PL_FUEL(p) < 5)
@@ -804,8 +795,7 @@ active(p)
    return 1;
 }
 
-starbase(e)
-
+int starbase(e)
    Player	*e;
 {
    if(!e || !e->p || !isAlive(e->p)) return 0;
@@ -813,8 +803,7 @@ starbase(e)
    return e->p->p_ship.s_type == STARBASE;
 }
 
-oggwarfare(type, e, j, edist)
-
+void oggwarfare(type, e, j, edist)
    int			type;
    Player		*e;
    struct player	*j;
@@ -838,8 +827,7 @@ oggwarfare(type, e, j, edist)
    }
 }
 
-too_close(e)
-
+int too_close(e)
    Player	*e;
 {
    return e->dist < e->hispr+2000;
@@ -847,8 +835,7 @@ too_close(e)
 
 /* was 5000 */
 
-get_fire_dist(e, j, edist)
-   
+int get_fire_dist(e, j, edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -861,8 +848,7 @@ get_fire_dist(e, j, edist)
    return 4000;
 }
 
-in_danger(p)
-
+int in_danger(p)
    Player	*p;
 {
    if(PL_DAMAGE(p) > 50 && PL_SHIELD(p) < 50)

--- a/robotd/redraw.c
+++ b/robotd/redraw.c
@@ -14,7 +14,7 @@
 
 int	_tcheck;
 
-intrupt()
+void intrupt()
 {
    static long     lastread;
    static int      prevread;
@@ -69,12 +69,12 @@ keep_reading:
 
 /* borg detect */
 
-borg_detect()
+void borg_detect()
 {
    register Player		*p;
    register struct player	*j;
    int				last_speedc, last_dirc;
-   register			i;
+   register int			i;
 
    for(i=0, p=_state.players; i < MAXPLAYER; i++,p++){
       if(!p->p || (p->p->p_status != PALIVE) || p->invisible)

--- a/robotd/reserved.c
+++ b/robotd/reserved.c
@@ -12,8 +12,8 @@
 #include <netdb.h>
 #include "packets.h"
 
-makeReservedPacket(packet)
-struct reserved_spacket *packet;
+void makeReservedPacket(packet)
+    struct reserved_spacket *packet;
 {
     int i;
 
@@ -23,11 +23,11 @@ struct reserved_spacket *packet;
     packet->type = SP_RESERVED;
 }
 
-encryptReservedPacket(spacket, cpacket, server, pno)
-struct reserved_spacket *spacket;
-struct reserved_cpacket *cpacket;
-char *server;
-int pno;
+void encryptReservedPacket(spacket, cpacket, server, pno)
+    struct reserved_spacket *spacket;
+    struct reserved_cpacket *cpacket;
+    char *server;
+    int pno;
 {
     struct hostent *hp;
     struct in_addr address;

--- a/robotd/robot.c
+++ b/robotd/robot.c
@@ -105,8 +105,7 @@ void R_NextCommand()
    _waiting_for_input = mtime(0);
 }
 
-goto_state()
-
+void goto_state()
 {
    switch(_state.state){
       
@@ -163,7 +162,7 @@ goto_state()
 }
 
 /* NS: 	S_UPDATE */
-s_no_hostile()
+void s_no_hostile()
 {
    int	f = MYFUEL() < 90;
    int  d = MYDAMAGE() > 0 || MYSHIELD() < 100;
@@ -203,7 +202,7 @@ s_no_hostile()
 
 /* just entered */
 /* NS: S_ENGAGE, S_UPDATE */
-s_update()
+void s_update()
 {
    int	f = fuel_check(), d = repair_check();
 
@@ -296,7 +295,7 @@ s_update()
       _state.state = S_NO_HOSTILE;
 }
 
-s_refit()
+void s_refit()
 {
    static int	refitting;
 
@@ -375,7 +374,7 @@ s_refit()
 
 /* plot course towards player */
 /* NS: S_DEFENSE, S_UPDATE */
-s_engage()
+void s_engage()
 {
    Player		*e = _state.current_target;
 
@@ -384,28 +383,28 @@ s_engage()
    engage(e);	/* engage.c */
 }
 
-s_assault()
+void s_assault()
 {
    _state.state = S_DEFENSE;
 
    assault();
 }
 
-s_getarmies()
+void s_getarmies()
 {
    _state.state = S_DEFENSE;
 
    getarmies();
 }
 
-s_ogg()
+void s_ogg()
 {
    _state.state = S_DEFENSE;
 
    ogg();
 }
 
-s_escort()
+void s_escort()
 {
    _state.state = S_DEFENSE;
 
@@ -413,7 +412,7 @@ s_escort()
 }
 
 /* go to controller */
-s_comehere()
+void s_comehere()
 {
    struct player	*j;
    unsigned char	crs, crs_r;
@@ -453,7 +452,7 @@ s_comehere()
    _state.state = S_DEFENSE;
 }
 
-do_defense()
+void do_defense()
 {
    Player		*e = _state.closest_e;
    int			speed = _state.p_desspeed, edist, phrange;
@@ -514,7 +513,7 @@ do_defense()
 }
 
 /* check for incoming and ready phaser & torps */
-s_defense()
+void s_defense()
 {
    Player		*e = _state.closest_e;
    int			num_hits;
@@ -578,7 +577,7 @@ s_defense()
    }
 }
 
-check_me_explode()
+void check_me_explode()
 {
    Player	*p = _state.closest_f;
    int		mdam;
@@ -603,8 +602,7 @@ check_me_explode()
 }
 
 
-check_dethis(num_hits, hittime)
-
+void check_dethis(num_hits, hittime)
    int	num_hits, hittime;
 {
    int	detconst;
@@ -654,7 +652,7 @@ check_dethis(num_hits, hittime)
       req_detonate("det");
 }
 
-s_disengage()
+void s_disengage()
 {
    disengage();		/* disengage.c */
 
@@ -662,7 +660,7 @@ s_disengage()
 }
 
 /* NS: S_DEFENSE */
-s_recharge()
+void s_recharge()
 {
    /* add shields? */
    int	damage = MYDAMAGE();
@@ -886,7 +884,7 @@ struct planet *find_safe_planet(e, dist, team)
    int			*dist;	/* returned */
    int			team;
 {
-   register		k;
+   register int		k;
    struct planet	*pl, *cpl=NULL;
    Player		*p;
    int			pdist, mindist=INT_MAX, ed;
@@ -992,8 +990,7 @@ int pltype_needed()
    return r;
 }
 
-plmatch(pl, r)
-
+int plmatch(pl, r)
    struct planet	*pl;
    int			r;
 {
@@ -1004,7 +1001,7 @@ plmatch(pl, r)
 
 struct planet *nearest_safe_planet()
 {
-   register			i;
+   register int			i;
    register struct planet	*pl;
    PlanetRec			*pls = _state.planets;
    int				r = pltype_needed();
@@ -1026,7 +1023,7 @@ struct planet *nearest_safe_planet()
    return home_planet();
 }
 
-rship_dist()
+int rship_dist()
 {
    int	dm = MYDAMAGE();
    switch(me->p_ship.s_type){
@@ -1048,15 +1045,15 @@ rship_dist()
    return 5000;
 }
 
-not_safe(pl, pcrs, pdist)
-
+int not_safe(pl, pcrs, pdist)
    struct planet	*pl;
    unsigned char	pcrs;
    int			pdist;
 {
-   register		i;
+   register int		i;
    register Player	*p;
    struct planet	*team_planet();
+   int			in_team_area();
 
    if(DEBUG & DEBUG_DISENGAGE)
       printf("Is planet %s safe: ", pl->pl_name);
@@ -1101,7 +1098,7 @@ not_safe(pl, pcrs, pdist)
 
 
 /* TODO: incorporate in dodge.c */
-phaser_plasmas()
+void phaser_plasmas()
 {
    register struct plasmatorp *pt;
    register int i, x, y;
@@ -1185,7 +1182,7 @@ phaser_plasmas()
 }
 
 /* needs repair */
-repair_check()
+int repair_check()
 {
    int	v = MYDAMAGE(), s = MYSHIELD(), vd = 0;
    switch(me->p_ship.s_type){
@@ -1261,7 +1258,7 @@ repair_check()
 }
 
 /* needs fuel */
-fuel_check()
+int fuel_check()
 {
    int v = MYFUEL();
 
@@ -1291,7 +1288,7 @@ fuel_check()
    return 0;
 }
 
-output_stats()
+void output_stats()
 {
    char	buf[80];
    /* include temperatures here*/
@@ -1302,8 +1299,7 @@ output_stats()
    response(buf);
 }
 
-output_pstats(p, s)
-   
+void output_pstats(p, s)
    Player	*p;
    char		*s;
 {
@@ -1336,9 +1332,9 @@ char *bp(p)
 }
 
 /* bomb & take stats */
-output_astats()
+void output_astats()
 {
-   register		i;
+   register int		i;
    register Player	*p;
 
    mprintf("team bombers: ");
@@ -1383,8 +1379,7 @@ output_astats()
    mprintf("\n");
 }
 
-req_set_speed(s, l, f)
-
+int req_set_speed(s, l, f)
    int	s;
    int	l;
    char	*f;
@@ -1396,7 +1391,7 @@ req_set_speed(s, l, f)
    if(s > _state.maxspeed) s = _state.maxspeed;
 
    if(inl && !status->tourn && !_state.itourn && !ignoreTMode)
-      return;
+      return 0;
 
    if(_state.p_desspeed != s){
       _state.p_desspeed = s;
@@ -1414,8 +1409,7 @@ static int		tfired, pfired, turned;
 static unsigned char	turned_dir, tfire_dir, pfired_dir;
 
 
-req_set_course(c)
-
+int req_set_course(c)
    unsigned char	c;
 {
    if(me->p_speed == 0) return 0;
@@ -1455,15 +1449,14 @@ req_set_course(c)
    return 0;
 }
 
-req_torp(crs)
-
+int req_torp(crs)
    unsigned char	crs;
 {
    extern	int	_tsent;
    int			now = mtime(0), t=0;
 
    if(expltest){
-      if(MYDAMAGE() < 50) return;
+      if(MYDAMAGE() < 50) return 0;
    }
 
    if(_state.no_weapon) return 0;
@@ -1520,8 +1513,7 @@ req_torp(crs)
       return -1; /* low on fuel or too many torps */
 }
 
-req_pltorp(dir)
-
+void req_pltorp(dir)
    unsigned char	dir;
 {
    if(_state.no_weapon) return;
@@ -1540,13 +1532,12 @@ req_pltorp(dir)
    sendPlasmaReq(dir);
 }
 
-req_phaser(crs, f)
-
+int req_phaser(crs, f)
    unsigned char	crs;
    int			f;
 {
    if(expltest){
-      if(MYDAMAGE() < 90) return;
+      if(MYDAMAGE() < 90) return 0;
    }
 
    if(_state.no_weapon /*&& !Xplhit*/) return 0;
@@ -1614,9 +1605,9 @@ req_phaser(crs, f)
    return 0;
 }
 
-req_planetlock(n)
+int req_planetlock(n)
 
-   int			n;
+     int			n;
 {
    sendPlanlockReq(n);
    if((DEBUG & DEBUG_DISENGAGE) && (me->p_flags & (PFORBIT|PFDOCK))){
@@ -1630,8 +1621,7 @@ req_planetlock(n)
    return 1;
 }
 
-req_playerlock(n)
-
+int req_playerlock(n)
    int			n;
 {
    sendPlaylockReq(n);
@@ -1643,7 +1633,7 @@ req_playerlock(n)
    return 1;
 }
 
-req_shields_up()
+int req_shields_up()
 {
    if(!(me->p_flags & PFSHIELD)){
       if(DEBUG & DEBUG_DISENGAGE){
@@ -1655,7 +1645,7 @@ req_shields_up()
    return 0;
 }
 
-req_shields_down()
+int req_shields_down()
 {
    if(me->p_flags & PFSHIELD){
       sendShieldReq(0);
@@ -1664,7 +1654,7 @@ req_shields_down()
    return 0;
 }
 
-req_repair_on()
+int req_repair_on()
 {
    if(!(me->p_flags & PFREPAIR)){
       if(DEBUG & DEBUG_DISENGAGE){
@@ -1678,8 +1668,7 @@ req_repair_on()
    return 0;
 }
 
-req_detonate(s)
-   
+int req_detonate(s)
    char	*s;
 {
    if(s)
@@ -1688,7 +1677,7 @@ req_detonate(s)
    return 1;
 }
 
-req_repair_off()
+int req_repair_off()
 {
    /* just in case */
    _state.p_desspeed = me->p_speed;
@@ -1701,7 +1690,7 @@ req_repair_off()
    return 0;
 }
 
-req_orbit()
+int req_orbit()
 {
    if(!(me->p_flags & PFORBIT)){
       /* note: _state.p_desdir is wrong after this */
@@ -1712,7 +1701,7 @@ req_orbit()
    return 0;
 }
 
-req_det_mytorps()
+void req_det_mytorps()
 {
    register int i;
 
@@ -1723,15 +1712,13 @@ req_det_mytorps()
    }
 }
 
-req_det_mytorp(i)
-
+void req_det_mytorp(i)
    int	i;
 {
    sendDetMineReq(i + (me->p_no * MAXTORP));
 }
 
-req_tractor_on(n)
-
+void req_tractor_on(n)
    int	n;
 {
    if(_state.no_weapon) return;
@@ -1750,8 +1737,7 @@ req_tractor_on(n)
    sendTractorReq(1, n);
 }
 
-req_tractor_off(s)
-   
+void req_tractor_off(s)
    char	*s;
 {
    if(me->p_flags & (PFTRACT | PFPRESS)){
@@ -1763,8 +1749,7 @@ req_tractor_off(s)
    _timers.tractor_limit = TRACTOR_TIME + rrnd(10);
 }
 
-req_pressor_on(n)
-
+void req_pressor_on(n)
    int	n;
 {
    if(_state.no_weapon) return;
@@ -1781,7 +1766,7 @@ req_pressor_on(n)
    sendRepressReq(1, n);
 }
 
-req_pressor_off()
+void req_pressor_off()
 {
    if(me->p_flags & (PFTRACT | PFPRESS)){
       sendRepressReq(0, me->p_no);
@@ -1792,7 +1777,7 @@ req_pressor_off()
    _timers.tractor_limit = TRACTOR_TIME + rrnd(10);
 }
 
-req_cloak_on()
+int req_cloak_on()
 {
    if(no_cloak) return 0;
 
@@ -1803,7 +1788,7 @@ req_cloak_on()
    return 0;
 }
 
-req_cloak_off(s)
+int req_cloak_off(s)
    char	*s;
 {
    if(me->p_flags & PFCLOAK){
@@ -1814,7 +1799,7 @@ req_cloak_off(s)
    return 0;
 }
 
-req_dock_on()
+int req_dock_on()
 {
    if(!(me->p_flags & PFDOCKOK)){
       sendDockingReq(1);
@@ -1823,7 +1808,7 @@ req_dock_on()
    return 0;
 }
 
-req_dock_off()
+int req_dock_off()
 {
    if(me->p_flags & PFDOCKOK){
       sendDockingReq(0);
@@ -1832,7 +1817,7 @@ req_dock_off()
    return 0;
 }
 
-req_bomb()
+int req_bomb()
 {
    if(!(me->p_flags & PFBOMB)){
       sendBombReq(1);
@@ -1841,7 +1826,7 @@ req_bomb()
    return 0;
 }
 
-req_beamdown()
+int req_beamdown()
 {
    if(!(me->p_flags & PFBEAMDOWN)){
       sendBeamReq(2);
@@ -1850,7 +1835,7 @@ req_beamdown()
    return 0;
 }
 
-req_beamup()
+int req_beamup()
 {
    if(!(me->p_flags & PFBEAMUP)){
       sendBeamReq(1);
@@ -1859,8 +1844,7 @@ req_beamup()
    return 0;
 }
 
-
-mtime(x)
+int mtime(x)
    int	x;
 {
    struct timeval tm;
@@ -1875,8 +1859,7 @@ mtime(x)
    return mtime_cache;
 }
 
-reset_r_info(team_r, ship_r, first, login)
-   
+int reset_r_info(team_r, ship_r, first, login)
    int	*team_r, *ship_r, first;
    char	*login;
 {
@@ -2015,8 +1998,7 @@ reset_r_info(team_r, ship_r, first, login)
    }
 }
 
-_reset_initial(team_r, ship_r, login)
-
+void _reset_initial(team_r, ship_r, login)
    int	*team_r, *ship_r, *login;
 {
    /* debug */
@@ -2066,7 +2048,7 @@ _reset_initial(team_r, ship_r, login)
    init_playertype(login);
 }
 
-send_initial()
+void send_initial()
 {
    mprintf("sending update %d\n", (int)(_state.timer_delay_ms * 100000.));
 
@@ -2074,25 +2056,22 @@ send_initial()
    init_comm();
 }
 
-ignore_edefault(s)
-
+void ignore_edefault(s)
    char	*s;	/* length MAXPLAYER+1 */
 {
-   register	i;
+   register int	i;
    for(i=0; i< MAXPLAYER; i++)
       s[i] = '0';
    s[i] = '\0';
 }
 
-ignore_enemy(p)
-
+int ignore_enemy(p)
    int	p;
 {
    return (_state.ignore_e[p] == '1');
 }
 
-ignoring_e(e)
-
+int ignoring_e(e)
    Player	*e;
 {
    if(!e || !e->p || !isAlive(e->p))
@@ -2105,14 +2084,13 @@ ignoring_e(e)
    return _state.ignore_e[e->p->p_no] == '1';
 }
 
-set_team(t)
-
+void set_team(t)
    int	t;
 {
    _state.team = t;
 }
 
-mymax_safe_speed()
+int mymax_safe_speed()
 {
    int	s;
    switch(me->p_ship.s_type){
@@ -2143,7 +2121,7 @@ mymax_safe_speed()
    return s;
 }
 
-myemg_speed()
+int myemg_speed()
 {
    int	s;
 
@@ -2161,7 +2139,7 @@ myemg_speed()
    return s;
 }
       
-mylowfuel_speed()
+int mylowfuel_speed()
 {
    int	s;
    switch(me->p_ship.s_type){
@@ -2196,7 +2174,7 @@ mylowfuel_speed()
    return s;
 }
 
-myfight_speed()
+int myfight_speed()
 {
    int	s;
    switch(me->p_ship.s_type){
@@ -2234,7 +2212,6 @@ void init_timers()
 }
 
 char *state_name(s)
-
    estate	s;
 {
    switch(s){
@@ -2258,7 +2235,7 @@ char *state_name(s)
 }
 
 /* every once in a while the server misses a crucial packet. */
-handle_unknown_problems()
+void handle_unknown_problems()
 {
    static int	last;
 
@@ -2276,8 +2253,7 @@ handle_unknown_problems()
       _state.lock = 0;
 }
 
-enemy_near_dead(e)
-
+int enemy_near_dead(e)
    Player	*e;
 {
    if(!e || !e->p || !isAlive(e->p))
@@ -2295,7 +2271,7 @@ enemy_near_dead(e)
       return 0;
 }
 
-init_servername()
+void init_servername()
 {
    extern char	*serverName;
    char		*s = serverName;
@@ -2328,8 +2304,7 @@ init_servername()
 }
 
 /* player type based on name */
-init_playertype(login)
-   
+void init_playertype(login)
    char	*login;
 {
    int	v = -1;

--- a/robotd/rwarfare.c
+++ b/robotd/rwarfare.c
@@ -10,8 +10,7 @@
 #include "packets.h"
 #include "robot.h"
 
-torp_attack_robot(e, j, edist)
-
+void torp_attack_robot(e, j, edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -24,8 +23,7 @@ torp_attack_robot(e, j, edist)
    attack_robot(e, j, edist);
 }
 
-phaser_attack_robot(e, j, edist)
-
+void phaser_attack_robot(e, j, edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -59,7 +57,6 @@ phaser_attack_robot(e, j, edist)
 }
 
 unsigned char predict_dir(odir, ndir, dist)
-
    unsigned char	odir, ndir;
    int			dist;
 {
@@ -86,8 +83,7 @@ unsigned char predict_dir(odir, ndir, dist)
       return ndir - NORMALIZE(x);
 }
 
-attack_robot(e, j, edist)
-   
+void attack_robot(e, j, edist)
    Player		*e;
    struct player	*j;
    int			edist;
@@ -227,8 +223,7 @@ attack_robot(e, j, edist)
    mprintf("unknown phase. %d\n", _timers.robot_attack);
 }
 
-ship_factor(s)
-
+int ship_factor(s)
    int	s;
 {
    switch(s){

--- a/robotd/ships.c
+++ b/robotd/ships.c
@@ -10,9 +10,9 @@
 #include "packets.h"
 #include "robot.h"
 
-init_ships()
+void init_ships()
 {
-   register			i;
+   register int			i;
    register struct player	*p;
    if(!players) return;
 

--- a/robotd/shmem.c
+++ b/robotd/shmem.c
@@ -39,8 +39,7 @@ struct r_shmemt {
 static struct r_shmemt 	*r_shmem;
 static int		shmid;
 
-shmem_rloc(i, x, y)
-
+void shmem_rloc(i, x, y)
    int	i;
    int	*x,*y;
 {
@@ -57,8 +56,7 @@ shmem_rloc(i, x, y)
    *y = r_shmem->ty[i];
 }
 
-shmem_updmyloc(x, y)
-
+void shmem_updmyloc(x, y)
    int	x,y;
 {
    if(!shmem) return;
@@ -66,8 +64,7 @@ shmem_updmyloc(x, y)
    r_shmem->ty[me->p_no] = y;
 }
 
-shmem_rtarg(i)
-
+int shmem_rtarg(i)
    int	i;
 {
    if(!shmem) return -1;
@@ -76,8 +73,7 @@ shmem_rtarg(i)
    return r_shmem->target[i]-1;
 }
 
-shmem_updmytarg(t)
-
+void shmem_updmytarg(t)
    int	t;
 {
    if(!shmem) return;
@@ -85,8 +81,7 @@ shmem_updmytarg(t)
    r_shmem->target[me->p_no] = t+1;
 }
 
-shmem_rsync(i)
-
+int shmem_rsync(i)
    int	i;
 {
    if(!shmem) return -1;
@@ -95,8 +90,7 @@ shmem_rsync(i)
    return r_shmem->sync[i] -1;
 }
 
-shmem_updmysync(t)
-
+void shmem_updmysync(t)
    int	t;
 {
    if(!shmem) return;
@@ -106,7 +100,7 @@ shmem_updmysync(t)
 
 /* on startup */
 
-shmem_open()
+void shmem_open()
 {
    int	create = 0;
 
@@ -154,7 +148,7 @@ shmem_open()
 
 /* on exit */
 
-shmem_check()
+void shmem_check()
 {
    r_shmem->robot[me->p_no] = 0;
    r_shmem->num_robots --;
@@ -166,12 +160,11 @@ shmem_check()
 }
 
 /* functions */
-shmem_cloakd(j)
-
+int shmem_cloakd(j)
    struct player	*j;
 {
-   register		i, k=0;
-   register		sumx=0, sumy=0;
+   register int		i, k=0;
+   register int		sumx=0, sumy=0;
    int			tv = mtime(0), htv;
 
    if(!(j->p_flags & PFCLOAK)){

--- a/robotd/socket.c
+++ b/robotd/socket.c
@@ -42,23 +42,23 @@ static int	debug;
 int	_tsent;
 
 
-int handleMessage(), handlePhaser(), handlePlyrInfo();
-int handlePlayer(), handleSelf(), handleStatus();
-int handleWarning(), handleTorp(), handleTorpInfo();
-int handlePlanet(), handleQueue(), handlePickok(), handleLogin();
-int handlePlasmaInfo(), handlePlasma();
-int handleKills(), handleFlags(), handlePStatus();
-int handleMotd(), handleMask();
-int handleBadVersion(), handlePlanetLoc();
-int handleHostile(), handleStats(), handlePlyrLogin();
-int handleReserved();
-int handleScan(), handleUdpReply(), handleSequence();
-int handleMasterComm();
+void handleMessage(), handlePhaser(), handlePlyrInfo();
+void handlePlayer(), handleSelf(), handleStatus();
+void handleWarning(), handleTorp(), handleTorpInfo();
+void handlePlanet(), handleQueue(), handlePickok(), handleLogin();
+void handlePlasmaInfo(), handlePlasma();
+void handleKills(), handleFlags(), handlePStatus();
+void handleMotd(), handleMask();
+void handleBadVersion(), handlePlanetLoc();
+void handleHostile(), handleStats(), handlePlyrLogin();
+void handleReserved();
+void handleScan(), handleUdpReply(), handleSequence();
+void handleMasterComm();
 #ifdef ATM
-int handleUdpReply(), handleSequence();
-int handleScan();
+void handleUdpReply(), handleSequence();
+void handleScan();
 #endif /* ATM */
-int handlePing(); /* ping.c */
+void handlePing(); /* ping.c */
 
 struct packet_handler handlers[] = {
     { 0, NULL },	/* record 0 */
@@ -195,7 +195,7 @@ static short fSpeed, fDirection, fShield, fOrbit, fRepair, fBeamup, fBeamdown,
         fCloak, fBomb, fDockperm, fPhaser, fPlasma, fPlayLock, fPlanLock,
         fTractor, fRepress;
 /* reset all the "force command" variables */
-resetForce()
+void resetForce()
 {
     fSpeed = fDirection = fShield = fOrbit = fRepair = fBeamup = fBeamdown =
     fCloak = fBomb = fDockperm = fPhaser = fPlasma = fPlayLock = fPlanLock =
@@ -250,7 +250,7 @@ resetForce()
                 force = -1;        }                                                       \
 }
 
-checkForce()
+void checkForce()
 {
     struct speed_cpacket speedReq;
     struct tractor_cpacket tractorReq;
@@ -275,8 +275,8 @@ checkForce()
 }
 #endif /* ATM */
 
-connectToServer(port)
-int port;
+void connectToServer(port)
+    int port;
 {
     int s;
     struct sockaddr_in addr;
@@ -369,7 +369,7 @@ tryagain:
     printf("Connection from server %s (%s)\n", serverName, inet_ntoa(addr.sin_addr));
 }
 
-set_tcp_opts(s)
+void set_tcp_opts(s)
    int  s;
 {
    int          optval=1, optlen;
@@ -384,9 +384,9 @@ set_tcp_opts(s)
       perror("setsockopt");
 }
 
-connectToRWatch(machine, port)
-char *machine;
-int port;
+int connectToRWatch(machine, port)
+    char *machine;
+    int port;
 {
     int ns;
     struct sockaddr_in addr;
@@ -434,7 +434,7 @@ int port;
 #define O_NDELAY O_NONBLOCK
 #endif /* !defined(O_NDELAY) */
 
-set_rsock_nowait()
+int set_rsock_nowait()
 {
    if(fcntl(rsock, F_SETFL, O_NDELAY) < 0) {
    perror("fcntl");
@@ -443,9 +443,9 @@ set_rsock_nowait()
    return 1;
 }
 
-callServer(port, server)
-int port;
-char *server;
+void callServer(port, server)
+    int port;
+    char *server;
 {
     int s;
     struct sockaddr_in addr;
@@ -487,7 +487,6 @@ char *server;
    }
 #endif
 
-
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
 
@@ -513,12 +512,12 @@ char *server;
     pickSocket(port);	/* new socket != port */
 }
 
-isServerDead()
+int isServerDead()
 {
     return(serverDead);
 }
 
-socketPause()
+void socketPause()
 {
     struct timeval timeout;
     fd_set	readfds;
@@ -536,8 +535,7 @@ socketPause()
 
 static    char _buf[BUFSIZ*2];
 #ifdef ATM
-readFromServer(pollmode)
-   
+void readFromServer(pollmode)
    int	pollmode;
 {
     struct timeval timeout;
@@ -612,8 +610,8 @@ sel_again:;
     return (retval != 0);               /* convert to 1/0 */
 }
 
-doRead(asock)
-int asock;
+int doRead(asock)
+    int asock;
 {
     struct timeval timeout;
     fd_set readfds;
@@ -738,7 +736,7 @@ int asock;
 }
 
 #else
-readFromServer()
+int readFromServer()
 {
     struct timeval timeout;
     fd_set readfds;
@@ -860,8 +858,8 @@ readFromServer()
 }
 #endif
 
-handleTorp(packet)
-struct torp_spacket *packet;
+void handleTorp(packet)
+    struct torp_spacket *packet;
 {
     struct torp *thetorp;
     extern int _tcheck;
@@ -883,26 +881,21 @@ struct torp_spacket *packet;
     thetorp->t_y=ntohl(packet->y);
     thetorp->t_dir=packet->dir;
 
-      
-
-   if(_state.borg_detect){
+    if(_state.borg_detect){
       Player	*p = &_state.players[thetorp->t_owner];
       if(p->tfire_dir < 0)
 	 p->tfire_dir = (int)thetorp->t_dir;
-   }
+    }
 }
 
-
-handleSTorp(sbuf)
-
+void handleSTorp(sbuf)
    unsigned char        *sbuf;
 {
-   register     i;
+   register int i;
    int          size;
    struct torp *thetorp, torp;
    struct player *j;
    register Player	*p;
-
 
    size = (int)sbuf[1];
    if(debug)
@@ -1015,8 +1008,8 @@ handleSTorp(sbuf)
    }
 }
 
-handleTorpInfo(packet)
-struct torp_info_spacket *packet;
+void handleTorpInfo(packet)
+    struct torp_info_spacket *packet;
 {
     struct torp *thetorp;
     struct player	*j;
@@ -1096,8 +1089,8 @@ struct torp_info_spacket *packet;
 #endif
 }
 
-handleStatus(packet)
-struct status_spacket *packet;
+void handleStatus(packet)
+    struct status_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleStatus");
@@ -1115,8 +1108,8 @@ struct status_spacket *packet;
     status->timeprod=ntohl(packet->timeprod);
 }
 
-handleSelf(packet)
-struct you_spacket *packet;
+void handleSelf(packet)
+    struct you_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleSelf");
@@ -1147,8 +1140,7 @@ tors */
 #endif
 }
 
-handleSelfShort(packet)
-
+void handleSelfShort(packet)
    struct youshort_spacket *packet;
 {
    me = &players[packet->pnum];
@@ -1162,8 +1154,7 @@ handleSelfShort(packet)
    me->p_whodead = packet->whodead;
 }
 
-handleSelfShip(packet)
-
+void handleSelfShip(packet)
    struct youss_spacket *packet;
 {
    if(!me)
@@ -1176,8 +1167,8 @@ handleSelfShip(packet)
    me->p_wtemp = ntohs(packet->wtemp);
 }
 
-handlePlayer(packet)
-struct player_spacket *packet;
+void handlePlayer(packet)
+   struct player_spacket *packet;
 {
    register struct player 	*pl;
    Player			*p;
@@ -1224,14 +1215,13 @@ struct player_spacket *packet;
    redrawPlayer[packet->pnum]=1;
 }
 
-handleSPlayer(sbuf)
-
+void handleSPlayer(sbuf)
    unsigned char        *sbuf;
 {
-   register                     i;
+   register int                 i;
    int                          size;
    register struct player       *pl;
-   register                     px,py;
+   register int                 px, py;
    unsigned char                dir;
    int                          offscreen;
    Player			*p;
@@ -1284,8 +1274,8 @@ handleSPlayer(sbuf)
    }
 }
 
-handleWarning(packet)
-struct warning_spacket *packet;
+void handleWarning(packet)
+    struct warning_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleWarning");
@@ -1298,12 +1288,12 @@ struct warning_spacket *packet;
 #endif
 }
 
-sendShortPacket(type, state)
-char type, state;
+void sendShortPacket(type, state)
+    char type, state;
 {
     struct speed_cpacket speedReq;
 
-   if(DEBUG & DEBUG_SERVER){
+    if(DEBUG & DEBUG_SERVER){
       switch(type){
 	 case CP_TORP:		printf("sendTorp: %d\n", state); break;
 	 case CP_PHASER:	printf("sendPhaser: %d\n", state); break;
@@ -1314,7 +1304,7 @@ char type, state;
 	 case CP_REPAIR:	printf("sendRepair: %d\n", state); break;
 	 default:		printf("unknownReq: %d %d\n", type, state);
       }
-   }
+    }
 
     speedReq.type=type;
     speedReq.speed=state;
@@ -1352,9 +1342,9 @@ char type, state;
 }
 
 #ifdef ATM
-sendServerPacket(packet)
+void sendServerPacket(packet)
 /* Pick a random type for the packet */
-struct player_spacket *packet;
+    struct player_spacket *packet;
 {
     int size;
 
@@ -1450,8 +1440,8 @@ send_udp:
 }
 #endif
 
-handlePlanet(packet)
-struct planet_spacket *packet;
+void handlePlanet(packet)
+   struct planet_spacket *packet;
 {
    struct planet *plan;
 
@@ -1477,8 +1467,8 @@ struct planet_spacket *packet;
    }
 }
 
-handlePhaser(packet)
-struct phaser_spacket *packet;
+void handlePhaser(packet)
+   struct phaser_spacket *packet;
 {
    struct phaser *phas;
    register Player	*p;
@@ -1514,8 +1504,8 @@ struct phaser_spacket *packet;
 #endif
 }
 
-handleMessage(packet)
-struct mesg_spacket *packet;
+void handleMessage(packet)
+    struct mesg_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleMessage");
@@ -1524,8 +1514,8 @@ struct mesg_spacket *packet;
     dmessage(packet->mesg, packet->m_flags, packet->m_from, packet->m_recpt);
 }
 
-handleQueue(packet)
-struct queue_spacket *packet;
+void handleQueue(packet)
+    struct queue_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleQueue");
@@ -1533,8 +1523,8 @@ struct queue_spacket *packet;
     queuePos = ntohs(packet->pos);
 }
 
-sendTeamReq(team,ship)
-int team, ship;
+void sendTeamReq(team,ship)
+    int team, ship;
 {
     struct outfit_cpacket outfitReq;
 
@@ -1545,8 +1535,8 @@ int team, ship;
     sendServerPacket(&outfitReq);
 }
 
-handlePickok(packet)
-struct pickok_spacket *packet;
+void handlePickok(packet)
+    struct pickok_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handlePickok");
@@ -1555,14 +1545,14 @@ struct pickok_spacket *packet;
     mprintf("got pickOk = %d\n", pickOk);
 }
 
-sendLoginReq(name,pass,login,query)
-char *name, *pass;
-char *login;
-char query;
+void sendLoginReq(name,pass,login,query)
+    char *name, *pass;
+    char *login;
+    char query;
 {
     struct login_cpacket packet;
     /* tmp */
-    register	i;
+    register int	i;
     strcpy(packet.name, name);
     strcpy(packet.password, pass);
     if (strlen(login)>15) login[15]=0;
@@ -1572,8 +1562,8 @@ char query;
     sendServerPacket(&packet);
 }
 
-handleLogin(packet)
-struct login_spacket *packet;
+void handleLogin(packet)
+    struct login_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleLogin");
@@ -1591,9 +1581,9 @@ struct login_spacket *packet;
     }
 }
 
-sendTractorReq(state, pnum)
-char state;
-char pnum;
+void sendTractorReq(state, pnum)
+    char state;
+    char pnum;
 {
     struct tractor_cpacket tractorReq;
 
@@ -1611,9 +1601,9 @@ char pnum;
 
 }
 
-sendRepressReq(state, pnum)
-char state;
-char pnum;
+void sendRepressReq(state, pnum)
+    char state;
+    char pnum;
 {
     struct repress_cpacket repressReq;
 
@@ -1631,8 +1621,8 @@ char pnum;
 
 }
 
-sendDetMineReq(torp)
-short torp;
+void sendDetMineReq(torp)
+    short torp;
 {
     struct det_mytorp_cpacket detReq;
 
@@ -1641,8 +1631,8 @@ short torp;
     sendServerPacket(&detReq);
 }
 
-handlePlasmaInfo(packet)
-struct plasma_info_spacket *packet;
+void handlePlasmaInfo(packet)
+   struct plasma_info_spacket *packet;
 {
    struct plasmatorp *thetorp;
    struct player	*j;
@@ -1686,8 +1676,8 @@ struct plasma_info_spacket *packet;
    }
 }
 
-handlePlasma(packet)
-struct plasma_spacket *packet;
+void handlePlasma(packet)
+    struct plasma_spacket *packet;
 {
     struct plasmatorp 	*thetorp;
 
@@ -1706,8 +1696,8 @@ struct plasma_spacket *packet;
 
 }
 
-handleFlags(packet)
-struct flags_spacket *packet;
+void handleFlags(packet)
+   struct flags_spacket *packet;
 {
    Player		*p;
    struct player	*j;
@@ -1746,11 +1736,10 @@ M - visible tractors */
         players[packet->pnum].p_tractor = -1;
 #endif
 #endif
-
 }
 
-handleKills(packet)
-struct kills_spacket *packet;
+void handleKills(packet)
+    struct kills_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleKills");
@@ -1759,8 +1748,8 @@ struct kills_spacket *packet;
     updatePlayer[packet->pnum]=1;
 }
 
-handlePStatus(packet)
-struct pstatus_spacket *packet;
+void handlePStatus(packet)
+    struct pstatus_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handlePStatus");
@@ -1787,8 +1776,8 @@ struct pstatus_spacket *packet;
     updatePlayer[packet->pnum]=1;
 }
 
-handleMotd(packet)
-struct motd_spacket *packet;
+void handleMotd(packet)
+    struct motd_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleMotd");
@@ -1798,9 +1787,9 @@ struct motd_spacket *packet;
 #endif
 }
 
-sendMessage(mes, group, indiv)
-char *mes;
-int group, indiv;
+void sendMessage(mes, group, indiv)
+    char *mes;
+    int group, indiv;
 {
     struct mesg_cpacket mesPacket;
 
@@ -1811,8 +1800,8 @@ int group, indiv;
     sendServerPacket(&mesPacket);
 }
 
-handleMask(packet)
-struct mask_spacket *packet;
+void handleMask(packet)
+    struct mask_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleMask");
@@ -1820,7 +1809,7 @@ struct mask_spacket *packet;
     tournMask=packet->mask;
 }
 
-sendOptionsPacket()
+void sendOptionsPacket()
 {
     struct options_cpacket optPacket;
 
@@ -1836,8 +1825,8 @@ sendOptionsPacket()
     sendServerPacket(&optPacket);
 }
 
-pickSocket(old)
-int old;
+void pickSocket(old)
+    int old;
 {
     int newsocket;
     struct socket_cpacket sockPack;
@@ -1858,8 +1847,8 @@ int old;
     nextSocket=newsocket;
 }
 
-handleBadVersion(packet)
-struct badversion_spacket *packet;
+void handleBadVersion(packet)
+    struct badversion_spacket *packet;
 {
 #ifdef DEBUG_SCK
     DEBUG_SOCKET("handleBadVersion");
@@ -1877,10 +1866,10 @@ struct badversion_spacket *packet;
     exit(1);
 }
 
-gwrite(fd, buf, bytes)
-int fd;
-char *buf;
-register int bytes;
+int gwrite(fd, buf, bytes)
+    int fd;
+    char *buf;
+    register int bytes;
 {
     long orig = bytes;
     register long n;
@@ -1903,8 +1892,8 @@ register int bytes;
     return(orig);
 }
 
-handleHostile(packet)
-struct hostile_spacket *packet;
+void handleHostile(packet)
+    struct hostile_spacket *packet;
 {
     register struct player *pl;
 
@@ -1918,8 +1907,8 @@ struct hostile_spacket *packet;
     redrawPlayer[packet->pnum]=1;
 }
 
-handlePlyrLogin(packet)
-struct plyr_login_spacket *packet;
+void handlePlyrLogin(packet)
+    struct plyr_login_spacket *packet;
 {
     register struct player *pl;
 
@@ -1948,8 +1937,8 @@ struct plyr_login_spacket *packet;
     }
 }
 
-handleStats(packet)
-struct stats_spacket *packet;
+void handleStats(packet)
+    struct stats_spacket *packet;
 {
     register struct player *pl;
 
@@ -1973,8 +1962,8 @@ struct stats_spacket *packet;
     pl->p_stats.st_sbmaxkills=ntohl(packet->sbmaxkills) / 100.0;
 }
 
-handlePlyrInfo(packet)
-struct plyr_info_spacket *packet;
+void handlePlyrInfo(packet)
+    struct plyr_info_spacket *packet;
 {
     register struct player *pl;
     static int lastship= -1;
@@ -1999,8 +1988,8 @@ struct plyr_info_spacket *packet;
     redrawPlayer[packet->pnum]=1;
 }
 
-sendUpdatePacket(speed)
-long speed;
+void sendUpdatePacket(speed)
+    long speed;
 {
     struct updates_cpacket packet;
 
@@ -2013,7 +2002,7 @@ long speed;
     sendServerPacket(&packet);
 }
 
-sendOggVPacket()
+void sendOggVPacket()
 {
    struct oggv_cpacket	packet;
    int			upd;
@@ -2086,11 +2075,11 @@ sendOggVPacket()
    sendServerPacket(&packet);
 }
 
-handlePlanetLoc(packet)
-struct planet_loc_spacket *packet;
+void handlePlanetLoc(packet)
+    struct planet_loc_spacket *packet;
 {
     struct planet *pl;
-static int plc;
+    static int plc;
 
     plc++;
     if(plc == MAXPLANETS)
@@ -2108,8 +2097,8 @@ static int plc;
     reinitPlanets=1;
 }
 
-handleReserved(packet)
-struct reserved_spacket *packet;
+void handleReserved(packet)
+    struct reserved_spacket *packet;
 {
     static struct reserved_cpacket response;
 
@@ -2127,8 +2116,7 @@ struct reserved_spacket *packet;
     sendServerPacket(&response);
 }
 
-updateR(j)
-
+void updateR(j)
    struct player	*j;
 {
    struct you_spacket	packet;
@@ -2161,8 +2149,7 @@ updateR(j)
    sendRPacket((struct player_spacket *) &packet, sizeof(packet));
 }
 
-sendRPacket(p, s)
-
+void sendRPacket(p, s)
    struct player_spacket *p;
    int			s;
 {
@@ -2172,7 +2159,7 @@ sendRPacket(p, s)
 
 #ifdef SCANNERS
 handleScan(packet)
-struct scan_spacket *packet;
+    struct scan_spacket *packet;
 {
     struct player *pp;
 
@@ -2188,8 +2175,7 @@ struct scan_spacket *packet;
     }
 }
 
-informScan(p)
-
+void informScan(p)
    int  p;
 {
 }
@@ -2200,8 +2186,8 @@ informScan(p)
 /*
  * UDP stuff
  */
-sendUdpReq(req)
-int req;
+void sendUdpReq(req)
+    int req;
 {
     struct udp_req_cpacket packet;
 
@@ -2283,8 +2269,8 @@ int req;
 #endif
 }
 
-handleUdpReply(packet)
-struct udp_reply_spacket *packet;
+void handleUdpReply(packet)
+    struct udp_reply_spacket *packet;
 {
     struct udp_req_cpacket response;
 
@@ -2369,7 +2355,7 @@ send:
 }
 
 #define MAX_PORT_RETRY  10
-openUdpConn()
+int openUdpConn()
 {
     struct sockaddr_in addr;
     struct hostent *hp;
@@ -2434,7 +2420,7 @@ openUdpConn()
     return (0);
 }
 #ifdef USE_PORTSWAP
-connUdpConn()
+int connUdpConn()
 {
     struct sockaddr_in addr;
 
@@ -2455,7 +2441,7 @@ connUdpConn()
 #endif
 
 #ifndef USE_PORTSWAP
-recvUdpConn()
+int recvUdpConn()
 {
     fd_set              readfds;
     struct timeval      to;
@@ -2523,7 +2509,7 @@ select_again:;
 }
 #endif
 
-closeUdpConn()
+int closeUdpConn()
 {
     V_UDPDIAG(("Closing UDP socket\n"));
     if (udpSock < 0) {
@@ -2537,7 +2523,7 @@ closeUdpConn()
     return 0;
 }
 
-printUdpInfo()
+void printUdpInfo()
 {
     struct sockaddr_in addr;
     socklen_t len;
@@ -2558,8 +2544,8 @@ printUdpInfo()
         addr.sin_family, ntohs(addr.sin_port)));
 }
 
-handleSequence(packet)
-struct sequence_spacket *packet;
+void handleSequence(packet)
+    struct sequence_spacket *packet;
 {
     static int recent_count=0, recent_dropped=0;
     long newseq;
@@ -2622,15 +2608,14 @@ struct sequence_spacket *packet;
 #endif
 
 
-handleMasterComm(packet)
-
+void handleMasterComm(packet)
    struct mastercomm_spacket	*packet;
 {
    recv_from_master(packet);
 }
 
    /* TMP */
-testcl(packet, response)
+void testcl(packet, response)
    struct reserved_spacket *packet;
    struct reserved_cpacket *response;
 {
@@ -2663,8 +2648,7 @@ static   struct you_spacket y;
    rsock = -1;
 }
 
-handleShortReply(packet)
-
+void handleShortReply(packet)
    struct shortreply_spacket *packet;
 {
    char	buf[60];
@@ -2675,8 +2659,7 @@ handleShortReply(packet)
    recv_short = packet->repl;
 }
 
-get_dist_speed(oldx, oldy, newx, newy, dir)
-
+int get_dist_speed(oldx, oldy, newx, newy, dir)
    int			oldx,oldy,newx,newy;
    unsigned char	dir;
 {

--- a/robotd/update_planets.c
+++ b/robotd/update_planets.c
@@ -10,12 +10,12 @@
 #include "packets.h"
 #include "robot.h"
 
-update_planets()
+void update_planets()
 {
-   register			k;
+   register int			k;
    register struct planet	*pl;
    PlanetRec			*pls = _state.planets;
-   register			d;
+   register int			d;
 
    pls->total_tarmies 		= 0;
    pls->total_textra_armies	= 0;
@@ -100,14 +100,14 @@ update_planets()
 #endif
 }
 
-_plcmp(el1, el2)
+int _plcmp(el1, el2)
 
    struct planet **el1, **el2;
 {
    return (*el1)->pl_mydist - (*el2)->pl_mydist;
 }
 
-sort_planets_by_distance()
+void sort_planets_by_distance()
 {
    PlanetRec			*pls = _state.planets;
 

--- a/robotd/update_players.c
+++ b/robotd/update_players.c
@@ -21,11 +21,11 @@
 Player 		*get_target();
 struct planet	*closest_planet();
 
-update_players()
+void update_players()
 {
    register struct player	*j, *closest = NULL;
    register Player		*p, *ce = NULL, *cf = NULL, *ct = NULL;
-   register			i;
+   register int			i;
    int				mce = INT_MAX, mcf = INT_MAX, mct = INT_MAX, d;
    int				pldist;
    int				predictx, predicty, rx,ry;
@@ -277,9 +277,9 @@ update_players()
    check_active_enemies();
 }
 
-check_active_enemies()
+void check_active_enemies()
 {
-   static timer;
+   static int timer;
 
    if(_state.total_enemies == 0){
       if(_state.player_type == PT_OGGER || _state.player_type == PT_DOGFIGHTER){
@@ -307,14 +307,10 @@ check_active_enemies()
    }
 }
 
-orbit_check(p, j)
-
+void orbit_check(p, j)
    Player		*p;
    struct player	*j;
 {
-
-
-
 /* begin -- only if PFORBIT not given by server */
 #ifdef NO_PFORBIT
    /* assume nothing has changed. */
@@ -407,8 +403,7 @@ orbit_check(p, j)
       p->pl_armies = 0;
 }
 
-army_check1(p, j)
-
+void army_check1(p, j)
    Player		*p;
    struct player	*j;
 {
@@ -451,11 +446,9 @@ army_check1(p, j)
       p->armies = 0;
    if(p->armies > troop_capacity(j))
       p->armies = troop_capacity(j);
-
 }
 
-army_check2(p, j)
-
+void army_check2(p, j)
    Player		*p;
    struct player	*j;
 {
@@ -541,15 +534,11 @@ army_check2(p, j)
    if(p->armies < 0) p->armies = 0;
    if(p->armies > troop_capacity(j))
       p->armies = troop_capacity(j);
-
-
 }
-
 
 /* A more intuitive way of figuring out who carries in 
    a pickup game. Only works with humans */
-army_check3(p, j)
-
+void army_check3(p, j)
    Player		*p;
    struct player	*j;
 {
@@ -583,22 +572,18 @@ army_check3(p, j)
 
 }
 
-NotRobot(p, j)
-
+int NotRobot(p, j)
    Player		*p;
    struct player	*j;
 {
-
     if ( (strcmp(j->p_login,"robot!") != 0) || !(j->p_flags&PFBPROBOT) ) { 
        return 1;
     } else {
        return 0;
     }
-
 }
 
-calc_speed(p, j)
-   
+int calc_speed(p, j)
    Player		*p;
    struct player	*j;
 {
@@ -633,8 +618,7 @@ calc_speed(p, j)
    return s;
 }
 
-cloak_check(p, j)
-
+void cloak_check(p, j)
    Player		*p;
    struct player	*j;
 {
@@ -718,8 +702,7 @@ cloak_check(p, j)
    */
 }
 
-init_sstats(p)
-
+void init_sstats(p)
    Player	*p;
 {
    register struct player	*j = p->p;
@@ -743,8 +726,7 @@ init_sstats(p)
    p->pl_armies	= 0;
 }
 
-update_sstats(e, ct)
-
+void update_sstats(e, ct)
    Player	*e;
    int		ct;
 {
@@ -770,8 +752,7 @@ update_sstats(e, ct)
    if(e->wpntemp < 0) e->wpntemp = 0;
 }
 
-addfuel(k, cycletime)
-
+int addfuel(k, cycletime)
    struct player	*k;
    int			cycletime;
 {
@@ -786,8 +767,7 @@ addfuel(k, cycletime)
 }
 
 /* xx -- put in util.c */
-fuel_planet(n)
-
+int fuel_planet(n)
    int	n;
 {
    struct planet	*pl = &planets[n];
@@ -796,8 +776,7 @@ fuel_planet(n)
    return (pl->pl_flags & PLFUEL);
 }
 
-repair_planet(n)
-
+int repair_planet(n)
    int	n;
 {
    struct planet	*pl = &planets[n];
@@ -806,8 +785,7 @@ repair_planet(n)
    return (pl->pl_flags & PLREPAIR);
 }
 
-subfuel(k, cycletime)
-   
+int subfuel(k, cycletime)
    struct player	*k;
    int			cycletime;
 {
@@ -835,8 +813,7 @@ subfuel(k, cycletime)
    return dfuel;
 }
 
-repair_shield(k,e, cycletime)
-
+void repair_shield(k,e, cycletime)
    struct player	*k;
    Player		*e;
    int			cycletime;
@@ -862,8 +839,7 @@ repair_shield(k,e, cycletime)
    }
 }
 
-repair_damage(k, e, cycletime)
-
+void repair_damage(k, e, cycletime)
    struct player	*k;
    Player		*e;
    int			cycletime;
@@ -890,8 +866,7 @@ repair_damage(k, e, cycletime)
 }
 
 /* called from init_dodge */
-add_damage(t, td, e)
-
+void add_damage(t, td, e)
    struct torp	*t;
    int		td;
    Player	*e;
@@ -940,8 +915,7 @@ add_damage(t, td, e)
    dodamage(e, j, dam);
 }
 
-dodamage(e, j, dam)
-
+void dodamage(e, j, dam)
    Player		*e;
    struct player	*j;
    int			dam;
@@ -970,11 +944,10 @@ dodamage(e, j, dam)
 
 /* sh just exploded */
 
-do_expdamage(sh)
-
+void do_expdamage(sh)
    struct player	*sh;
 {
-   register			i;
+   register int			i;
    int				dx,dy,dist;
    int				damage;
    register struct player	*j;
@@ -1037,7 +1010,7 @@ do_expdamage(sh)
 */
 int declare_intents(int peaceonly)
 {
-   register			i;
+   register int			i;
    register struct player	*j;
    int				teams[16], maxt=0, maxcount=0;
    int				maxt2=0, maxcount2=0;
@@ -1124,8 +1097,7 @@ int declare_intents(int peaceonly)
 
 /* DEBUG*/
 
-print_player(e)
-
+void print_player(e)
    Player	*e;
 {
    printf("name: \"%s\"(%d)\n", e->p->p_name, e->p->p_no);
@@ -1138,11 +1110,8 @@ print_player(e)
    printf("damage: %d%%\n", PL_DAMAGE(e));
 }
 
-
 Player *get_target(closest_target)
-   
    Player	*closest_target;
-
 {
    Player	*l;
    Player	*getany(), *getabase();
@@ -1210,8 +1179,7 @@ Player *get_target(closest_target)
       return closest_target;
 }
 
-process_general_message(message, flags, from, to)
-   
+void process_general_message(message, flags, from, to)
    char			*message;
    unsigned char	flags,from,to;
 {
@@ -1245,17 +1213,15 @@ process_general_message(message, flags, from, to)
    }
 }
 
-tractor_check(e, j)
-   
+void tractor_check(e, j)
    Player		*e;
    struct player	*j;
 {
 
    int			predictx, predicty, 
 			predict_trx, predict_try, edist;
-   register		currx, curry, rtx, rty, rx, ry;
+   register int		currx, curry, rtx, rty, rx, ry;
    int			trx, try;
-
 
 #ifndef NO_PFTRACT
    e->pp_flags &= ~PFTRACT;
@@ -1322,10 +1288,10 @@ tractor_check(e, j)
 #endif /* NO_PFTRACT */
 }
 
-update_player_density()
+void update_player_density()
 {
-   register			i,j;
-   register Player		*p,*e;
+   register int			i, j;
+   register Player		*p, *e;
    register struct player	*fr, *en;
    int				st;
    unsigned char		crs;
@@ -1426,9 +1392,9 @@ update_player_density()
 #endif
 }
 
-calc_attackdiff()
+void calc_attackdiff()
 {
-   register		i,j;
+   register int		i, j;
    register Player	*p;
    Player		*pe[MAXPLAYER];
    int	    		my_pno = me->p_no;
@@ -1480,15 +1446,13 @@ calc_attackdiff()
 
 /* SSS: speed critical */
 struct planet	*closest_planet(j, dist, opl)
-
    struct player	*j;
    int			*dist;
    struct planet	*opl;
-
 {
-   register			k;
+   register int			k;
    register struct planet	*pl, *rp = opl;
-   register			d, mdist = INT_MAX;
+   register int			d, mdist = INT_MAX;
 
    if(opl && (mdist = ihypot((double)(j->p_x - opl->pl_x), 
 			     (double)(j->p_y - opl->pl_y))) < 3000){
@@ -1515,7 +1479,7 @@ struct planet	*closest_planet(j, dist, opl)
 
 Player *getany()
 {
-   register 		i;
+   register int		i;
    register Player	*p;
    struct planet	*hp, *team_planet();
 
@@ -1541,7 +1505,7 @@ Player *getany()
 
 Player *getabase()
 {
-   register 		i;
+   register int		i;
    register Player	*p;
    struct planet	*hp, *team_planet();
    int			sbs[MAXPLAYER], sbf = 0;
@@ -1573,18 +1537,16 @@ Player *getabase()
 
 /* make sure edge didn't set off explosion */
 
-edge_expl(t)
-
+int edge_expl(t)
    struct torp	*t;
 {
-   register	i = t->t_x,
+   register int	i = t->t_x,
 		j = t->t_y;
    
    return (!i || i == GWIDTH || !j || j == GWIDTH);
 }
 
-sync_check(t)
-   
+int sync_check(t)
    Player	**t;
 {
    Player	*targ = *t;
@@ -1611,11 +1573,11 @@ sync_check(t)
    return 1;
 }
 
-check_sync_loop()
+void check_sync_loop()
 {
    struct player	*j;
    char			buf[30];
-   register		i = _state.ogg_pno-1, k=0, q;
+   register int		i = _state.ogg_pno-1, k=0, q;
    for(k=0; k< MAXPLAYER+1; k++){
       q = shmem_rsync(i);
       /*

--- a/robotd/util.c
+++ b/robotd/util.c
@@ -17,7 +17,7 @@
 
 struct distress *loaddistress(enum dist_type i);
 
-mprintf(char *format, ...)
+void mprintf(char *format, ...)
 {
    va_list	ap;
 
@@ -33,8 +33,8 @@ mprintf(char *format, ...)
 /*
 ** Provide the angular distance between two angles.
 */
-angdist(x, y)
-unsigned char x, y;
+int angdist(x, y)
+    unsigned char x, y;
 {
     register unsigned char res;
 
@@ -47,13 +47,13 @@ unsigned char x, y;
 
 #ifdef hpux
 
-srandom(foo)
-int foo;
+void srandom(foo)
+    int foo;
 {
     rand(foo);
 }
 
-random()
+int random()
 {
     return(rand());
 }
@@ -61,9 +61,9 @@ random()
 #include <time.h>
 #include <sys/resource.h>
 
-getrusage(foo, buf)
-int foo;
-struct rusage *buf;
+void getrusage(foo, buf)
+    int foo;
+    struct rusage *buf;
 {
     buf->ru_utime.tv_sec = 0;
     buf->ru_stime.tv_sec = 0;
@@ -71,10 +71,9 @@ struct rusage *buf;
 
 #include <sys/signal.h>
 
-int (*
-signal(sig, funct))()
-int sig;
-int (*funct)();
+int (*signal(sig, funct))()
+    int sig;
+    int (*funct)();
 {
     struct sigvec vec, oldvec;
 
@@ -84,8 +83,7 @@ int (*funct)();
 }
 #endif
 
-warning(s, o)
-
+void warning(s, o)
    char	*s;
    int	o;
 {
@@ -98,15 +96,13 @@ warning(s, o)
 
 
 /* return rnd between -range & range */
-rrnd(range)
-
+int rrnd(range)
    int  range;
 {
    return RANDOM() % (2*range) - range;
 }
 
-edist_to_me(j)
-
+int edist_to_me(j)
    struct player        *j;
 {
    if(_state.wrap_around)
@@ -118,8 +114,7 @@ edist_to_me(j)
    }
 }
 
-pdist_to_p(j1, j2)
-
+int pdist_to_p(j1, j2)
    struct player	*j1,*j2;
 {
    if(_state.wrap_around)
@@ -131,18 +126,19 @@ pdist_to_p(j1, j2)
    }
 }
 
-unsigned char get_wrapcourse(x,y)
-
-   int	x,y;
+unsigned char get_wrapcourse(x, y)
+   int x, y;
 {
-   if(!_state.wrap_around) return get_course(x,y);
+   if(!_state.wrap_around)
+      return get_course(x,y);
    else
       return get_course(wrap_x(x, me->p_x), wrap_y(y, me->p_y));
 }
 
-wrap_x(x, mx)
+int wrap_x(x, mx)
+   int x, mx;
 {
-   register	xd = x - mx;
+   register int xd = x - mx;
 
    if(xd < 0){
       if(-xd > GWIDTH/2)
@@ -155,9 +151,10 @@ wrap_x(x, mx)
    return x;
 }
 
-wrap_y(y, my)
+int wrap_y(y, my)
+   int y, my;
 {
-   register	yd = y - my;
+   register int yd = y - my;
    if(yd < 0){
       if(-yd > GWIDTH/2)
 	 y = GWIDTH + y;
@@ -169,7 +166,8 @@ wrap_y(y, my)
    return y;
 }
 
-wrap_dist(x1, y1, x,y)
+int wrap_dist(x1, y1, x, y)
+   int x1, y1, x, y;
 {
    int	xr = wrap_x(x, x1),
 	yr = wrap_y(y, y1);
@@ -180,8 +178,8 @@ wrap_dist(x1, y1, x,y)
 }
 
 /* get course from me to x,y */
-unsigned char get_course(x,y)
-int     x,y;
+unsigned char get_course(x, y)
+   int     x, y;
 {
    unsigned char	ret_crs;
 
@@ -193,9 +191,8 @@ int     x,y;
 }
 
 /* get course from (mx,my) to (x,y) */
-unsigned char get_acourse(x,y, mx,my)
-
-   int	x,y,mx,my;
+unsigned char get_acourse(x, y, mx, my)
+   int x, y, mx, my;
 {
    if(x == mx && y == my)
       return 0;
@@ -204,25 +201,23 @@ unsigned char get_acourse(x,y, mx,my)
       (double) (my - y)) / 3.14159 * 128.);
 }
 
-unsigned char get_awrapcourse(x,y, mx,my)
-
-   int	x,y;
+unsigned char get_awrapcourse(x, y, mx, my)
+   int x, y, mx, my;
 {
-   if(!_state.wrap_around) return get_acourse(x,y,mx,my);
+   if(!_state.wrap_around)
+      return get_acourse(x,y,mx,my);
    else
       return get_course(wrap_x(x, mx), wrap_y(y,my));
 }
 
 /* return distance of closest enemy to planet in question */
-edist_to_planet(pl)
-
+int edist_to_planet(pl)
    struct planet        *pl;
 {
    return dist_to_planet(_state.closest_e, pl);
 }
 
-dist_to_planet(e,pl)
-
+int dist_to_planet(e, pl)
    Player		*e;
    struct planet	*pl;
 {
@@ -243,8 +238,7 @@ dist_to_planet(e,pl)
    return d;
 }
 
-mydist_to_planet(pl)
-
+int mydist_to_planet(pl)
    struct planet        *pl;
 {
    return dist_to_planet(me_p, pl);
@@ -252,10 +246,10 @@ mydist_to_planet(pl)
 
 /* returns angdst of enemy course & given course <= range given,
    i.e. is difference of enemy course to given course within range? */
-running_away(e, crs, r)
-
+int running_away(e, crs, r)
    Player                *e;
    unsigned char        crs;
+   int	                  r;
 {
    return angdist(e->p->p_dir, crs) <= r;
 }
@@ -263,10 +257,10 @@ running_away(e, crs, r)
 /* returns true if enemy 'e' is "attacking" the specified
    approaching course */
 
-attacking(e, crs, r)
-
+int attacking(e, crs, r)
    Player                *e;
    unsigned char        crs;
+   int	                  r;
 {
    unsigned char        ecrs = e->p->p_dir;
    unsigned int		rd = crs - 128;
@@ -275,8 +269,7 @@ attacking(e, crs, r)
    return angdist((unsigned char)rd, ecrs) <= r;
 }
 
-avoiddir(dir, mcrs, r)
-
+int avoiddir(dir, mcrs, r)
    unsigned char	dir, 	/* course to be avoided */
 			r;	/* range of direction change */
    unsigned char        *mcrs;	/* my course -- used and returned */
@@ -307,8 +300,7 @@ avoiddir(dir, mcrs, r)
 /* defend */
 
 /* how close do we get? */
-defend_dist(p)
-
+int defend_dist(p)
    Player	*p;
 {
    struct planet	*pl, *team_planet();
@@ -328,7 +320,7 @@ defend_dist(p)
 }
 
 /* what's too close */
-tdefend_dist()
+int tdefend_dist()
 {
    if(starbase(_state.protect_player))
       return 4000;
@@ -337,13 +329,12 @@ tdefend_dist()
 }
 
 /* how close to enemy before attack */
-edefend_dist()
+int edefend_dist()
 {
    return 9000;
 }
 
 unsigned char choose_course(scrs, ecrs)
-
    unsigned char scrs;
    unsigned char ecrs;
 {
@@ -358,11 +349,10 @@ unsigned char choose_course(scrs, ecrs)
       return (unsigned char) (ecrs + 80);
 }
 
-on_screen(p)
-
+int on_screen(p)
    Player	*p;
 {
-   register	x,y;
+   register int x, y;
    if(!p || !p->p || !isAlive(p->p))
       return 0;
    
@@ -376,7 +366,7 @@ on_screen(p)
 
 #define TIME(x)		((_udcounter - (x))/10)
 
-do_alert()
+void do_alert()
 {
    static int	lastalert;
    int		critical = 0;
@@ -405,7 +395,7 @@ do_alert()
    }
 }
 
-emergency()
+void emergency()
 {
     struct distress *dist;
 
@@ -422,7 +412,7 @@ emergency()
 int ihypot(xd1, yd1)
    double xd1, yd1;
 {
-   register 	x1 = (int)xd1,
+   register int	x1 = (int)xd1,
 		y1 = (int)yd1,
 		x2 = 0, 
 		y2 = 0;
@@ -433,8 +423,7 @@ int ihypot(xd1, yd1)
 }
 
 #if ! HAVE_NINT
-nint(x)
-   
+int nint(x)
    double x;
 {
    double	rint();
@@ -442,7 +431,7 @@ nint(x)
 }
 #endif
 
-mfprintf(FILE *fo, char *format, ...)
+void mfprintf(FILE *fo, char *format, ...)
 {
    va_list	ap;
 
@@ -454,4 +443,3 @@ mfprintf(FILE *fo, char *format, ...)
    fflush(fo);
    va_end(ap);
 }
-

--- a/robotd/warfare.c
+++ b/robotd/warfare.c
@@ -19,8 +19,7 @@ int		dtint;
 int		dgo;
 
 
-warfare(type)
-   
+void warfare(type)
    int	type;
 {
    Player		*e = _state.current_target;
@@ -81,8 +80,7 @@ warfare(type)
    }
 }
 
-rship_ok(n, s)
-
+int rship_ok(n, s)
    char		*n;
    int		s;
 {
@@ -103,12 +101,11 @@ rship_ok(n, s)
    }
 }
 
-qtorps(size, urnd, tcrs)
-
+void qtorps(size, urnd, tcrs)
    int	size, urnd;
    unsigned char	tcrs;
 {
-   register	i;
+   register int i;
    int	v;
 
    for(i=0; i < size; i++){
@@ -123,8 +120,7 @@ qtorps(size, urnd, tcrs)
    }
 }
 
-qtorp(crs)
-
+void qtorp(crs)
    unsigned char        crs;
 {
    TorpQ	*tq = _state.torpq;
@@ -142,7 +138,7 @@ qtorp(crs)
 }
 
 /* called from intrupt() */
-do_torps()
+void do_torps()
 {
    int  		r;
    unsigned char	tdir;
@@ -167,15 +163,14 @@ do_torps()
    /* otherwise just mistimed */
 }
 
-emptytorpq()
+void emptytorpq()
 {
    TorpQ	*tq = _state.torpq;
    tq->ntorps = 0;
    tq->ipos = tq->opos = 0;
 }
 
-get_torp_course(j, crs, cx,cy)
-
+int get_torp_course(j, crs, cx,cy)
    struct player        *j;
    unsigned char        *crs;
    int			cx,cy;
@@ -257,16 +252,14 @@ get_torp_course(j, crs, cx,cy)
    return 0;
 }
 
-get_orbit_torp_course(j, crs, cx, cy)
-   
+void get_orbit_torp_course(j, crs, cx, cy)
    struct player	*j;
    unsigned char	*crs;
    int			cx,cy;
 {
-   register		x,y, px,py;
+   register int		x, y, px, py;
    int			edist,cycles;
    unsigned char	dir;
-   double		dx,dy;
 
    px = planets[j->p_planet].pl_x;
    py = planets[j->p_planet].pl_y;
@@ -288,8 +281,7 @@ get_orbit_torp_course(j, crs, cx, cy)
 }
 
 /* called from update_players */
-planet_from_ppos(j)
-
+int planet_from_ppos(j)
    struct player	*j;
 {
    int				x,y;
@@ -325,8 +317,7 @@ planet_from_ppos(j)
    return -1;
 }
       
-phaser_condition(e, edist)
-
+int phaser_condition(e, edist)
    Player	*e;
    int		edist;
 {


### PR DESCRIPTION
The previous code presumed that a `saltbuf` parameter would be passed as
`char[3]` rather than `char*`, and incorrectly calculated the salt length
as `size(char*)-2`. On a 32-bit platform, this would result in `2`, which
is the correct answer. However, on a 64-bit platform, it would result in
`6`, which is not the correct answer.

GCC warned about this. With -Werror, it reported:

```
salt.c: In function ‘salt’:
salt.c:24:25: error: ‘sizeof’ on array function parameter ‘sb’ will return size of ‘char *’ [-Werror=sizeof-array-argument]
     int saltlen = sizeof(sb) - 2;
                     ^
salt.c:20:35: note: declared here
 char* salt(const char* s, saltbuf sb)
                               ^
cc1: all warnings being treated as errors
```

As crypt() only looks for the first two bytes to use as salt, this may
not have lead to a change in crypt() calculation. However, writing 7 bytes
to a buffer that is only 3 bytes in length may lead to a buffer overflow.
