### PR TITLE
Fix global 'hours' buffer overflow

### DIFF
--- a/ntserv/timecheck.c
+++ b/ntserv/timecheck.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -41,9 +42,11 @@ int time_access(void)
         tfd = fopen(Time_File,"r");
 
         for (day=0; day<=6; day++) {
-          if (fscanf(tfd, "%s", hours[day]) == EOF)
+          char buf[25];
+          if (fgets(buf, 25, tfd) != NULL)
             if (ferror(tfd))
-              perror("time_access: fscanf");
+              perror("time_access: fgets");
+              memcpy(hours[day], buf, 24);
         }
 
         fclose(tfd);


### PR DESCRIPTION
When loading the hours file, ntserv uses fscanf() to read play hours
line-by-line into a global 'hours' buffer. Since there are 24 hours in a
day, each day is an array of 24 hours. However, fscanf() also copies the
terminating NUL character. This results in a buffer overflow in the
default installation when parsing the last line.

This fix uses fgets() to read up to 25 characters (including the
trailing NUL), and then copies the first 24 characters into the global
'hours' buffer.