### PR TITLE
fix missing ship bug

### DIFF
--- a/robots/puckmove.c
+++ b/robots/puckmove.c
@@ -714,7 +714,7 @@ void do_teleport_home(void)
 	j->p_speed = 0;
 	j->p_desspeed = 0;
 	j->p_subspeed = 0;
-	j->p_flags = PFSHIELD;
+	j->p_flags = PFSHIELD | PFSEEN;
 	j->p_fuel   = j->p_ship.s_maxfuel;
 	j->p_shield = j->p_ship.s_maxshield;
 	j->p_damage = 0;


### PR DESCRIPTION
This seems to fix it.

Added the PFSEEN flag when the ships get teleported back after a goal.

@hyperyoda 