### PR TITLE
Comment lines in metaservers file no longer count towards the 8 server max limit

### DIFF
--- a/ntserv/solicit.c
+++ b/ntserv/solicit.c
@@ -144,6 +144,7 @@ static void initialise()
   file = fopen(SYSCONFDIR"/metaservers", "r");
   if (file == NULL) file = fopen(SYSCONFDIR"/.metaservers", "r");
   if (file == NULL) {
+    ERROR(1,("solicit: No metaservers file found.\n"));
     initialised++;
     return;
   }
@@ -164,13 +165,17 @@ static void initialise()
     if (feof(file)) break;
 
     /* ignore comments */
-    if (line[0] == '#') continue;
+    if (line[0] == '#') {
+      i--;
+      continue;
+    }
 
     /* parse each field, ignore the line if insufficient fields found */
 
     token = strtok(line, " ");        /* meta host name */
     if (token == NULL) continue;
     strncpy(m->host, token, 32);
+    ERROR(1,("solicit: Using metaserver: %s\n", m->host));
 
     token = strtok(NULL, " ");        /* meta port */
     if (token == NULL) continue;


### PR DESCRIPTION
The metaservers example file contains a number of explanative comments. Unfortunately the comments themselves were counted as entries for the metaserver array. Since there's a hard maximum of 8 servers, appending actual metaserver names at the end of the file results in ntserv solicit quietly failing. I've changed the code to simply not count comment lines as one of the 8 entries, which makes the default file work as intended. I did not want to introduce a lot of new changes, but I added some error log output that should be useful for startup.